### PR TITLE
Provide roles for auth

### DIFF
--- a/datastore/mock_database.go
+++ b/datastore/mock_database.go
@@ -348,6 +348,20 @@ func (mdb *MockDB) ListUsers() ([]User, error) {
 		Name:           "Nancy Reagan",
 		Email:          "nancy.reagan@usa.gov",
 		Role:           Admin})
+	users = append(users, User{
+		ID:             3,
+		Username:       "sv",
+		OpenIDIdentity: "https://login.ubuntu.com/+id/Stfnvlter",
+		Name:           "Steven Vault",
+		Email:          "sv@example.com",
+		Role:           Standard})
+	users = append(users, User{
+		ID:             4,
+		Username:       "a",
+		OpenIDIdentity: "https://login.ubuntu.com/+id/AAAAAA",
+		Name:           "A",
+		Email:          "a@example.com",
+		Role:           Standard})
 	return users, nil
 }
 

--- a/datastore/mock_database.go
+++ b/datastore/mock_database.go
@@ -361,7 +361,7 @@ func (mdb *MockDB) ListUsers() ([]User, error) {
 		OpenIDIdentity: "https://login.ubuntu.com/+id/AAAAAA",
 		Name:           "A",
 		Email:          "a@example.com",
-		Role:           Standard})
+		Role:           Superuser})
 	return users, nil
 }
 

--- a/usso/jwt.go
+++ b/usso/jwt.go
@@ -32,13 +32,14 @@ import (
 )
 
 // NewJWTToken creates a new JWT from the verified OpenID response
-func NewJWTToken(resp *openid.Response) (string, error) {
+func NewJWTToken(resp *openid.Response, role int) (string, error) {
 	token := jwt.New(jwt.SigningMethodHS256)
 
 	token.Claims[ClaimsUsername] = resp.SReg["nickname"]
 	token.Claims[ClaimsName] = resp.SReg["fullname"]
 	token.Claims[ClaimsEmail] = resp.SReg["email"]
 	token.Claims[ClaimsIdentity] = resp.ID
+	token.Claims[ClaimsRole] = role
 	token.Claims[StandardClaimExpiresAt] = time.Now().Add(time.Hour * 24).Unix()
 
 	tokenString, err := token.SignedString([]byte(jwtSecret))

--- a/usso/openid_test.go
+++ b/usso/openid_test.go
@@ -60,7 +60,7 @@ func TestLoginHandlerUSSORedirect(t *testing.T) {
 
 func TestLoginHandlerReturn(t *testing.T) {
 	// Response parameters from OpenID login
-	const url = "/login?openid.ns=http://specs.openid.net/auth/2.0&openid.mode=id_res&openid.op_endpoint=https://login.ubuntu.com/%2Bopenid&openid.claimed_id=https://login.ubuntu.com/%2Bid/AAAAAA&openid.identity=https://login.ubuntu.com/%2Bid/AAAAAA&openid.return_to=http://return.to&openid.response_nonce=2005-05-15T17:11:51ZUNIQUE&openid.assoc_handle=1&openid.signed=op_endpoint,return_to,response_nonce,assoc_handle,claimed_id,identity,sreg.email,sreg.fullname&openid.sig=AAAA&openid.ns.sreg=http://openid.net/extensions/sreg/1.1&openid.sreg.email=a@example.org&openid.sreg.fullname=A"
+	const url = "/login?openid.ns=http://specs.openid.net/auth/2.0&openid.mode=id_res&openid.op_endpoint=https://login.ubuntu.com/%2Bopenid&openid.claimed_id=https://login.ubuntu.com/%2Bid/AAAAAA&openid.identity=https://login.ubuntu.com/%2Bid/AAAAAA&openid.return_to=http://return.to&openid.response_nonce=2005-05-15T17:11:51ZUNIQUE&openid.assoc_handle=1&openid.signed=op_endpoint,return_to,response_nonce,assoc_handle,claimed_id,identity,sreg.email,sreg.fullname&openid.sig=AAAA&openid.ns.sreg=http://openid.net/extensions/sreg/1.1&openid.sreg.email=a@example.org&openid.sreg.fullname=A&openid.sreg.nickname=a"
 
 	// Mock the database and OpenID verification
 	datastore.Environ = &datastore.Env{DB: &datastore.MockDB{}}
@@ -85,12 +85,19 @@ func TestLoginHandlerReturn(t *testing.T) {
 
 	// Check the JWT details
 	response, _ := verifySuccess("")
-	expectedToken(t, jwtToken, response, response.SReg["nickname"], response.SReg["email"], response.SReg["fullname"])
+
+	// Get User Role
+	user, err := datastore.Environ.DB.GetUser(response.SReg["nickname"])
+	if err != nil {
+		t.Errorf("Could not get datastore user %v: %v\n", response.SReg["nickname"], err)
+	}
+
+	expectedToken(t, jwtToken, response, response.SReg["nickname"], response.SReg["email"], response.SReg["fullname"], user.Role)
 }
 
 func TestLoginHandlerReturnFail(t *testing.T) {
 	// Response parameters from OpenID login
-	const url = "/login?openid.ns=http://specs.openid.net/auth/2.0&openid.mode=id_res&openid.op_endpoint=https://login.ubuntu.com/%2Bopenid&openid.claimed_id=https://login.ubuntu.com/%2Bid/AAAAAA&openid.identity=https://login.ubuntu.com/%2Bid/AAAAAA&openid.return_to=http://return.to&openid.response_nonce=2005-05-15T17:11:51ZUNIQUE&openid.assoc_handle=1&openid.signed=op_endpoint,return_to,response_nonce,assoc_handle,claimed_id,identity,sreg.email,sreg.fullname&openid.sig=AAAA&openid.ns.sreg=http://openid.net/extensions/sreg/1.1&openid.sreg.email=a@example.org&openid.sreg.fullname=A"
+	const url = "/login?openid.ns=http://specs.openid.net/auth/2.0&openid.mode=id_res&openid.op_endpoint=https://login.ubuntu.com/%2Bopenid&openid.claimed_id=https://login.ubuntu.com/%2Bid/AAAAAA&openid.identity=https://login.ubuntu.com/%2Bid/AAAAAA&openid.return_to=http://return.to&openid.response_nonce=2005-05-15T17:11:51ZUNIQUE&openid.assoc_handle=1&openid.signed=op_endpoint,return_to,response_nonce,assoc_handle,claimed_id,identity,sreg.email,sreg.fullname&openid.sig=AAAA&openid.ns.sreg=http://openid.net/extensions/sreg/1.1&openid.sreg.email=a@example.org&openid.sreg.fullname=A&openid.sreg.nickname=a"
 
 	// Mock the database and OpenID verification
 	datastore.Environ = &datastore.Env{DB: &datastore.MockDB{}}
@@ -109,7 +116,7 @@ func verifySuccess(requestURL string) (*openid.Response, error) {
 	r := openid.Response{
 		ID:    "AAAAAA",
 		Teams: []string{"ce-web-logs"},
-		SReg:  map[string]string{"nickname": "sv", "fullname": "Steven Vault", "email": "sv@example.com"},
+		SReg:  map[string]string{"nickname": "sv", "fullname": "Steven Vault", "email": "sv@example.com", "role": "100"},
 	}
 
 	return &r, nil


### PR DESCRIPTION
Read database user related to openid response received nickname. Inject its role into JWT header when composed
Updated tests