### PR TITLE
Fix broken httpd-2.4.25 source link

### DIFF
--- a/snaps/serial-vault-services/snap/snapcraft.yaml
+++ b/snaps/serial-vault-services/snap/snapcraft.yaml
@@ -161,7 +161,7 @@ parts:
 
   apache:
     plugin: apache
-    source: http://ftp.wayne.edu/apache/httpd/httpd-2.4.25.tar.bz2
+    source: https://archive.apache.org/dist/httpd/httpd-2.4.25.tar.bz2
     source-checksum: sha1/bd6d138c31c109297da2346c6e7b93b9283993d2
 
     # The built-in Apache modules to enable


### PR DESCRIPTION
This fixes the broken httpd link required when creating the snap