### PR TITLE
Fix JWT claim properties 

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,5 +1,5 @@
 github.com/cheggaaa/pb	git	0817e3a1f8de9e3c78b159699b3c07d53e24a963	2017-03-23T12:38:18Z
-github.com/dgrijalva/jwt-go	git	afef698c326bfd906b11659432544e5aae441d44	2015-12-30T18:00:00Z
+github.com/dgrijalva/jwt-go	git	a539ee1a749a2b895533f979515ac7e6e0f5b650	2017-06-08T02:51:49Z
 github.com/gorilla/context	git	08b5f424b9271eedf6f9f0ce86cb9396ed337a42	2016-08-17T18:46:32Z
 github.com/gorilla/csrf	git	69581736821c33d85bbf378f42f6ad864dbd85de	2016-11-22T16:45:00Z
 github.com/gorilla/handlers	git	a5775781a543af3c6b9f5baf10995e4d14168950	2016-08-16T18:47:29Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,5 +1,5 @@
 github.com/cheggaaa/pb	git	0817e3a1f8de9e3c78b159699b3c07d53e24a963	2017-03-23T12:38:18Z
-github.com/dgrijalva/jwt-go	git d2709f9f1f31ebcda9651b03077758c1f3a0018c 2016-06-16T19:15:56Z
+github.com/dgrijalva/jwt-go	git	d2709f9f1f31ebcda9651b03077758c1f3a0018c	2016-06-16T19:15:56Z
 github.com/gorilla/context	git	08b5f424b9271eedf6f9f0ce86cb9396ed337a42	2016-08-17T18:46:32Z
 github.com/gorilla/csrf	git	69581736821c33d85bbf378f42f6ad864dbd85de	2016-11-22T16:45:00Z
 github.com/gorilla/handlers	git	a5775781a543af3c6b9f5baf10995e4d14168950	2016-08-16T18:47:29Z

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,5 +1,5 @@
 github.com/cheggaaa/pb	git	0817e3a1f8de9e3c78b159699b3c07d53e24a963	2017-03-23T12:38:18Z
-github.com/dgrijalva/jwt-go	git	a539ee1a749a2b895533f979515ac7e6e0f5b650	2017-06-08T02:51:49Z
+github.com/dgrijalva/jwt-go	git d2709f9f1f31ebcda9651b03077758c1f3a0018c 2016-06-16T19:15:56Z
 github.com/gorilla/context	git	08b5f424b9271eedf6f9f0ce86cb9396ed337a42	2016-08-17T18:46:32Z
 github.com/gorilla/csrf	git	69581736821c33d85bbf378f42f6ad864dbd85de	2016-11-22T16:45:00Z
 github.com/gorilla/handlers	git	a5775781a543af3c6b9f5baf10995e4d14168950	2016-08-16T18:47:29Z

--- a/service/utils.go
+++ b/service/utils.go
@@ -30,8 +30,8 @@ import (
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/usso"
-	"github.com/snapcore/snapd/asserts"
 	"github.com/dgrijalva/jwt-go"
+	"github.com/snapcore/snapd/asserts"
 )
 
 // DeviceAssertion defines the device identity.

--- a/service/utils.go
+++ b/service/utils.go
@@ -31,6 +31,7 @@ import (
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/usso"
 	"github.com/snapcore/snapd/asserts"
+	"github.com/dgrijalva/jwt-go"
 )
 
 // DeviceAssertion defines the device identity.
@@ -217,7 +218,8 @@ func checkUserPermissions(w http.ResponseWriter, r *http.Request) (string, error
 	}
 
 	// Get the user from the token
-	username := token.Claims[usso.ClaimsUsername].(string)
+	claims := token.Claims.(jwt.MapClaims)
+	username := claims[usso.ClaimsUsername].(string)
 
 	// Check that the role is at least an Admin
 	role := datastore.Environ.DB.RoleForUser(username)

--- a/usso/jwt.go
+++ b/usso/jwt.go
@@ -34,12 +34,13 @@ import (
 func createJWT(username, name, email, identity string, role int, expires int64) (string, error) {
 	token := jwt.New(jwt.SigningMethodHS256)
 
-	token.Claims[ClaimsUsername] = username
-	token.Claims[ClaimsName] = name
-	token.Claims[ClaimsEmail] = email
-	token.Claims[ClaimsIdentity] = identity
-	token.Claims[ClaimsRole] = role
-	token.Claims[StandardClaimExpiresAt] = expires
+	claims := token.Claims.(jwt.MapClaims)
+	claims[ClaimsUsername] = username
+	claims[ClaimsName] = name
+	claims[ClaimsEmail] = email
+	claims[ClaimsIdentity] = identity
+	claims[ClaimsRole] = role
+	claims[StandardClaimExpiresAt] = expires
 
 	tokenString, err := token.SignedString([]byte(jwtSecret))
 	if err != nil {

--- a/usso/jwt_test.go
+++ b/usso/jwt_test.go
@@ -73,7 +73,7 @@ func expectedToken(t *testing.T, jwtToken string, resp *openid.Response, usernam
 	if err != nil {
 		t.Errorf("Error validating JWT: %v", err)
 	}
-	
+
 	claims := token.Claims.(jwt.MapClaims)
 	if claims[ClaimsIdentity] != resp.ID {
 		t.Errorf("JWT ID does not match: %v", claims[ClaimsIdentity])

--- a/usso/jwt_test.go
+++ b/usso/jwt_test.go
@@ -24,8 +24,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/juju/usso/openid"
 	"github.com/dgrijalva/jwt-go"
+	"github.com/juju/usso/openid"
 )
 
 type testJWT struct {

--- a/usso/jwt_test.go
+++ b/usso/jwt_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/juju/usso/openid"
+	"github.com/dgrijalva/jwt-go"
 )
 
 type testJWT struct {
@@ -72,21 +73,22 @@ func expectedToken(t *testing.T, jwtToken string, resp *openid.Response, usernam
 	if err != nil {
 		t.Errorf("Error validating JWT: %v", err)
 	}
-
-	if token.Claims[ClaimsIdentity] != resp.ID {
-		t.Errorf("JWT ID does not match: %v", token.Claims[ClaimsIdentity])
+	
+	claims := token.Claims.(jwt.MapClaims)
+	if claims[ClaimsIdentity] != resp.ID {
+		t.Errorf("JWT ID does not match: %v", claims[ClaimsIdentity])
 	}
-	if token.Claims[ClaimsUsername] != username {
-		t.Errorf("JWT username does not match: %v", token.Claims[ClaimsUsername])
+	if claims[ClaimsUsername] != username {
+		t.Errorf("JWT username does not match: %v", claims[ClaimsUsername])
 	}
-	if token.Claims[ClaimsEmail] != email {
-		t.Errorf("JWT email does not match: %v", token.Claims[ClaimsEmail])
+	if claims[ClaimsEmail] != email {
+		t.Errorf("JWT email does not match: %v", claims[ClaimsEmail])
 	}
-	if token.Claims[ClaimsName] != name {
-		t.Errorf("JWT name does not match: %v", token.Claims[ClaimsName])
+	if claims[ClaimsName] != name {
+		t.Errorf("JWT name does not match: %v", claims[ClaimsName])
 	}
-	if int(token.Claims[ClaimsRole].(float64)) != role {
-		t.Errorf("JWT role does not match: expected %v but got %v", role, token.Claims[ClaimsRole])
+	if int(claims[ClaimsRole].(float64)) != role {
+		t.Errorf("JWT role does not match: expected %v but got %v", role, claims[ClaimsRole])
 	}
 }
 


### PR DESCRIPTION
The jwt-go package has upgraded to version 3 and has changed the way claim properties are accessed from tokens