### PR TITLE
remove openId_identity only if column exists to prevent error when da…

### DIFF
--- a/datastore/usermanager.go
+++ b/datastore/usermanager.go
@@ -68,7 +68,7 @@ const findAccountUserSQL = `
 const deleteUserAccountsSQL = "delete from useraccountlink where user_id=$1"
 const linkAccountToUserSQL = "insert into useraccountlink (user_id, account_id) values ($1,$2)"
 
-const alterUserRemoveOpenIDIdentity = "alter table userinfo drop column openid_identity"
+const alterUserRemoveOpenIDIdentity = "alter table userinfo drop column if exists openid_identity"
 
 // Available user roles:
 //


### PR DESCRIPTION
…tabase update

This fixes error thrown in massive db update when executed that user alter table command