### PR TITLE
config was used with single hyphen instead of two dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ If you have a Go development environment set up, Go get it:
 - Create the database tables:
   ```bash
   $ cd serial-vault
-  $ go run cmd/createddb/main.go -config=/path/to/settings.yaml
+  $ go run cmd/serial-vault-admin/main.go database --config=/path/to/settings.yaml
   ```
 
 ### Run it:
   ```bash
   $ cd serial-vault
-  $ go run server.go -config=/path/to/settings.yaml -mode=signing
+  $ go run cmd/serial-vault/main.go -config=/path/to/settings.yaml -mode=signing
   ```
 
 The application has an admin service that can be run by using mode=admin.

--- a/bin/snap-run-admin
+++ b/bin/snap-run-admin
@@ -2,4 +2,4 @@
 
 cd $SNAP
 
-bin/serial-vault-admin $@
+bin/serial-vault-admin --config=$SNAP_DATA/settings.yaml $@

--- a/bin/snap-run-service
+++ b/bin/snap-run-service
@@ -2,5 +2,7 @@
 
 cd $SNAP
 
-bin/serial-vault-admin database -config=$SNAP_DATA/settings.yaml
+bin/serial-vault-admin database --config=$SNAP_DATA/settings.yaml
+#TODO It is needed to modify serial-vault params to be set in same way as admin tool.
+#That would set coherence in both services using -- or - for long and short params.
 bin/serial-vault -config=$SNAP_DATA/settings.yaml


### PR DESCRIPTION
Fixes snap-run-service script which was not finding config yaml file.