### PR TITLE
support an extended registration protocol with an optional model assertion

### DIFF
--- a/service/errors.go
+++ b/service/errors.go
@@ -36,6 +36,7 @@ var (
 	ErrorNilData            = ErrorResponse{false, "nil-data", "", "Uninitialized POST data", http.StatusBadRequest}
 	ErrorEmptyData          = ErrorResponse{false, "empty-data", "", "No data supplied for signing", http.StatusBadRequest}
 	ErrorInvalidType        = ErrorResponse{false, "invalid-type", "", "The assertion type must be 'serial'", http.StatusBadRequest}
+	ErrorInvalidSecondType  = ErrorResponse{false, "invalid-second-type", "", "The 2nd assertion type must be 'model'", http.StatusBadRequest}
 	ErrorInvalidNonce       = ErrorResponse{false, "invalid-nonce", "", "Nonce is invalid or expired", http.StatusBadRequest}
 	ErrorInvalidModel       = ErrorResponse{false, "invalid-model", "", "Cannot find model with the matching brand and model", http.StatusBadRequest}
 	ErrorInactiveModel      = ErrorResponse{false, "invalid-model", "", "The model is linked with an inactive signing-key", http.StatusBadRequest}

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -123,6 +123,7 @@ func SignHandler(w http.ResponseWriter, r *http.Request) ErrorResponse {
 	dec := asserts.NewDecoder(r.Body)
 	assertion, err := dec.Decode()
 	if err == io.EOF {
+		logMessage("SIGN", "invalid-assertion", "No data supplied for signing")
 		return ErrorEmptyData
 	}
 	if err != nil {
@@ -156,14 +157,13 @@ func SignHandler(w http.ResponseWriter, r *http.Request) ErrorResponse {
 	// Double check the model assertion if present
 	if modelAssert != nil {
 		if modelAssert.Type() != asserts.ModelType {
-			logMessage("SIGN", "invalid-type", "The 2nd assertion type must be 'model'")
-			return ErrorInvalidType
+			logMessage("SIGN", "invalid-second-type", "The 2nd assertion type must be 'model'")
+			return ErrorInvalidSecondType
 		}
 		if modelAssert.HeaderString("brand-id") != assertion.HeaderString("brand-id") || modelAssert.HeaderString("model") != assertion.HeaderString("model") {
-			const msg = "model and serial-request assertion do not match"
-			logMessage("SIGN", "invalid-assertion", msg)
-			return ErrorResponse{false, "model-mismatch", "", msg, http.StatusBadRequest}
-
+			const msg = "Model and serial-request assertion do not match"
+			logMessage("SIGN", "mismatched-model", msg)
+			return ErrorResponse{false, "mismatched-model", "", msg, http.StatusBadRequest}
 		}
 
 		// TODO: ideally check the signature of model, need access

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -117,22 +117,32 @@ func SignHandler(w http.ResponseWriter, r *http.Request) ErrorResponse {
 		return ErrorNilData
 	}
 
-	// Read the full request body
-	data, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		logMessage("SIGN", "invalid-assertion", err.Error())
-		return ErrorResponse{false, "error-sign-read", "", err.Error(), http.StatusBadRequest}
-	}
-	if len(data) == 0 {
-		logMessage("SIGN", "invalid-assertion", "No data supplied for signing")
-		return ErrorEmptyData
-	}
-
 	defer r.Body.Close()
 
-	// Use the snapd assertions module to decode the body and validate
-	assertion, err := asserts.Decode(data)
+	// Use snapd assertion module to decode the assertions in the request stream
+	dec := asserts.NewDecoder(r.Body)
+	assertion, err := dec.Decode()
+	if err == io.EOF {
+		return ErrorEmptyData
+	}
 	if err != nil {
+		logMessage("SIGN", "invalid-assertion", err.Error())
+		return ErrorResponse{false, "decode-assertion", "", err.Error(), http.StatusBadRequest}
+	}
+
+	// Decode the optional model
+	modelAssert, err := dec.Decode()
+	if err != nil && err != io.EOF {
+		logMessage("SIGN", "invalid-assertion", err.Error())
+		return ErrorResponse{false, "decode-assertion", "", err.Error(), http.StatusBadRequest}
+	}
+
+	// Stream must be ended now
+	_, err = dec.Decode()
+	if err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("unexpected assertion in the request stream")
+		}
 		logMessage("SIGN", "invalid-assertion", err.Error())
 		return ErrorResponse{false, "decode-assertion", "", err.Error(), http.StatusBadRequest}
 	}
@@ -141,6 +151,23 @@ func SignHandler(w http.ResponseWriter, r *http.Request) ErrorResponse {
 	if assertion.Type() != asserts.SerialRequestType {
 		logMessage("SIGN", "invalid-type", "The assertion type must be 'serial-request'")
 		return ErrorInvalidType
+	}
+
+	// Double check the model assertion if present
+	if modelAssert != nil {
+		if modelAssert.Type() != asserts.ModelType {
+			logMessage("SIGN", "invalid-type", "The 2nd assertion type must be 'model'")
+			return ErrorInvalidType
+		}
+		if modelAssert.HeaderString("brand-id") != assertion.HeaderString("brand-id") || modelAssert.HeaderString("model") != assertion.HeaderString("model") {
+			const msg = "model and serial-request assertion do not match"
+			logMessage("SIGN", "invalid-assertion", msg)
+			return ErrorResponse{false, "model-mismatch", "", msg, http.StatusBadRequest}
+
+		}
+
+		// TODO: ideally check the signature of model, need access
+		// to the brand public key(s) for models
 	}
 
 	// Verify that the nonce is valid and has not expired


### PR DESCRIPTION
This will also cross-check the serial-request with the model assertion if present.

As discussed in

https://forum.snapcraft.io/t/opt-in-accepting-distribution-of-generic-signed-serials/2011

we plan to extend to registration protocol from snapd to include also the model assertion so that it can carry flags to control the serial emission, this is not directly relevant as such so far for the serial-vault itself but the serial-vault needs nevertheless to accept the extra assertion in the stream, and at least lightly cross-check it.

TODO:
* docs updates?