### PR TITLE
The model assertion API call returns multiple assertions

### DIFF
--- a/service/handlers_assertion.go
+++ b/service/handlers_assertion.go
@@ -98,14 +98,13 @@ func ModelAssertionHandler(w http.ResponseWriter, r *http.Request) ErrorResponse
 	return ErrorResponse{Success: true}
 }
 
-func fetchAssertionFromStore(assertions *[]asserts.Assertion, modelType *asserts.AssertionType, headers []string) error {
+func fetchAssertionFromStore(assertions *[]asserts.Assertion, modelType *asserts.AssertionType, headers []string) {
 	accountKeyAssertion, err := account.FetchAssertionFromStore(modelType, headers)
 	if err != nil {
 		logMessage("MODEL", "assertion", err.Error())
 	} else {
 		*assertions = append(*assertions, accountKeyAssertion)
 	}
-	return nil
 }
 
 func createModelAssertionHeaders(m datastore.Model) (map[string]interface{}, datastore.Keypair, error) {

--- a/service/handlers_assertion_test.go
+++ b/service/handlers_assertion_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/CanonicalLtd/serial-vault/account"
 	"github.com/CanonicalLtd/serial-vault/config"
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/snapcore/snapd/asserts"
@@ -46,7 +47,10 @@ type AssertionTest struct {
 
 var _ = check.Suite(&AssertionSuite{})
 
-func (s *AssertionSuite) SetUpSuite(c *check.C) {
+func (s *AssertionSuite) SetUpTest(c *check.C) {
+	// Mock the store
+	account.FetchAssertionFromStore = account.MockFetchAssertionFromStore
+
 	// Mock the database
 	config := config.Settings{KeyStoreType: "filesystem", KeyStorePath: "../keystore", JwtSecret: "SomeTestSecretValue"}
 	datastore.Environ = &datastore.Env{DB: &datastore.MockDB{}, Config: config}

--- a/service/utils.go
+++ b/service/utils.go
@@ -65,6 +65,23 @@ func formatSignResponse(success bool, errorCode, errorSubcode, message string, a
 	return nil
 }
 
+func formatAssertionResponse(success bool, errorCode, errorSubcode, message string, assertions []asserts.Assertion, w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", asserts.MediaType)
+	w.WriteHeader(http.StatusOK)
+	encoder := asserts.NewEncoder(w)
+
+	for _, assert := range assertions {
+		err := encoder.Encode(assert)
+		if err != nil {
+			// Not much we can do if we're here - apart from panic!
+			log.Println("Error encoding the assertions.")
+			return err
+		}
+	}
+
+	return nil
+}
+
 func formatModelsResponse(success bool, errorCode, errorSubcode, message string, models []ModelSerialize, w http.ResponseWriter) error {
 	response := ModelsResponse{Success: success, ErrorCode: errorCode, ErrorSubcode: errorSubcode, ErrorMessage: message, Models: models}
 


### PR DESCRIPTION
The model assertion API returns the Account and Account-Key assertions as well as the model assertion, as the device needs these to 'snap ack' the model assertion.