### PR TITLE
Integrate govendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ stage
 *.tar.bz2
 snap/.snapcraft
 .tests-extras
+vendor/*/

--- a/bin/snap-run-admin
+++ b/bin/snap-run-admin
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-cd $SNAP
+cd "$SNAP"
 
-bin/serial-vault-admin --config=$SNAP_DATA/settings.yaml $@
+bin/serial-vault-admin --config="$SNAP_DATA"/settings.yaml "$@"

--- a/bin/snap-run-service
+++ b/bin/snap-run-service
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-cd $SNAP
+cd "$SNAP"
 
-bin/serial-vault-admin database --config=$SNAP_DATA/settings.yaml
+bin/serial-vault-admin database --config="$SNAP_DATA"/settings.yaml
 #TODO It is needed to modify serial-vault params to be set in same way as admin tool.
 #That would set coherence in both services using -- or - for long and short params.
-bin/serial-vault -config=$SNAP_DATA/settings.yaml
+bin/serial-vault -config="$SNAP_DATA"/settings.yaml

--- a/datastore/dbkeypairoperator.go
+++ b/datastore/dbkeypairoperator.go
@@ -40,6 +40,9 @@ type DatabaseKeypairOperator struct{}
 func (dbStore *DatabaseKeypairOperator) ImportKeypair(authorityID, keyID, base64PrivateKey string) (string, error) {
 	// Generate an HMAC hash of the auth-key
 	authKeyHash, err := dbStore.generateEncryptionKey(authorityID, keyID)
+	if err != nil {
+		return "", err
+	}
 
 	// Use the HMAC-ed auth-key as the key to encrypt the signing-key
 	sealedSigningKey, err := crypt.EncryptKey(base64PrivateKey, authKeyHash)

--- a/datastore/keystore.go
+++ b/datastore/keystore.go
@@ -92,7 +92,7 @@ func getKeyStore(config config.Settings) (*KeypairDatabase, error) {
 		return &keypairDB, err
 
 	case TPM20Store.Name:
-		// Initalize the TPM store
+		// Initialize the TPM store
 		tpm20 := TPM20KeypairOperator{config.KeyStorePath, config.KeyStoreSecret, &tpm20Command{}}
 
 		// Prepare the memory store for the unsealed keys

--- a/datastore/mock_database.go
+++ b/datastore/mock_database.go
@@ -413,7 +413,7 @@ func (mdb *MockDB) ListUsers() ([]User, error) {
 		Email:    "rigoberto.picaporte@ubuntu.com",
 		Role:     Standard,
 		Accounts: []Account{
-			Account{
+			{
 				ID:          1,
 				AuthorityID: "authority1",
 				Assertion:   "assertioncontent1",
@@ -426,7 +426,7 @@ func (mdb *MockDB) ListUsers() ([]User, error) {
 		Email:    "nancy.reagan@usa.gov",
 		Role:     Standard,
 		Accounts: []Account{
-			Account{
+			{
 				ID:          2,
 				AuthorityID: "authority2",
 				Assertion:   "assertioncontent2",
@@ -439,12 +439,12 @@ func (mdb *MockDB) ListUsers() ([]User, error) {
 		Email:    "sv@example.com",
 		Role:     Admin,
 		Accounts: []Account{
-			Account{
+			{
 				ID:          3,
 				AuthorityID: "authority3",
 				Assertion:   "assertioncontent3",
 			},
-			Account{
+			{
 				ID:          4,
 				AuthorityID: "authority4",
 				Assertion:   "assertioncontent4",
@@ -635,8 +635,8 @@ func (mdb *MockDB) ListSubstores(accountID int, authorization User) ([]Substore,
 	fromModel, _ := mdb.GetAllowedModel(1, authorization)
 
 	substores := []Substore{
-		Substore{ID: 1, AccountID: 1, FromModelID: fromModel.ID, FromModel: fromModel, Store: "mybrand", SerialNumber: "abc1234", ModelName: "alder-mybrand"},
-		Substore{ID: 2, AccountID: 1, FromModelID: fromModel.ID, FromModel: fromModel, Store: "mybrand", SerialNumber: "abc5678", ModelName: "alder-mybrand"},
+		{ID: 1, AccountID: 1, FromModelID: fromModel.ID, FromModel: fromModel, Store: "mybrand", SerialNumber: "abc1234", ModelName: "alder-mybrand"},
+		{ID: 2, AccountID: 1, FromModelID: fromModel.ID, FromModel: fromModel, Store: "mybrand", SerialNumber: "abc5678", ModelName: "alder-mybrand"},
 	}
 
 	return substores, nil
@@ -1036,8 +1036,8 @@ func (mdb *ErrorMockDB) ListSubstores(accountID int, authorization User) ([]Subs
 	fromModel, _ := mdb.GetAllowedModel(1, authorization)
 
 	substores := []Substore{
-		Substore{ID: 1, FromModelID: fromModel.ID, FromModel: fromModel, Store: "mybrand", SerialNumber: "abc1234", ModelName: "alder-mybrand"},
-		Substore{ID: 1, FromModelID: fromModel.ID, FromModel: fromModel, Store: "mybrand", SerialNumber: "abc5678", ModelName: "alder-mybrand"},
+		{ID: 1, FromModelID: fromModel.ID, FromModel: fromModel, Store: "mybrand", SerialNumber: "abc1234", ModelName: "alder-mybrand"},
+		{ID: 1, FromModelID: fromModel.ID, FromModel: fromModel, Store: "mybrand", SerialNumber: "abc5678", ModelName: "alder-mybrand"},
 	}
 
 	return substores, errors.New("Cannot list the sub-stores")

--- a/datastore/modelmanager.go
+++ b/datastore/modelmanager.go
@@ -143,7 +143,7 @@ type Model struct {
 	KeyID           string         `json:"key-id"`            // from the signing keypair
 	KeyActive       bool           `json:"key-active"`        // from the signing keypair
 	SealedKey       string         `json:"-"`                 // from the signing keypair
-	KeypairIDUser   int            `json:"key-id-user"`       // from the system-user keypair
+	KeypairIDUser   int            `json:"keypair-id-user"`   // from the system-user keypair
 	AuthorityIDUser string         `json:"authority-id-user"` // from the system-user keypair
 	KeyIDUser       string         `json:"key-id-user"`       // from the system-user keypair
 	KeyActiveUser   bool           `json:"key-active-user"`   // from the system-user keypair

--- a/datastore/tpm20keypairoperator.go
+++ b/datastore/tpm20keypairoperator.go
@@ -179,13 +179,13 @@ func (tpmStore *TPM20KeypairOperator) createKey(primaryKeyContextPath, algorithm
 	os.Remove(privateKey.Name())
 	os.Remove(nameFile.Name())
 
-	// Create the key in the heirarchy
+	// Create the key in the hierarchy
 	err = tpmStore.tpmCommand.runCommand("tpm2_create", "-g", algSHA256, "-G", algorithm, "-c", primaryKeyContextPath, "-o", publicKey.Name(), "-O", privateKey.Name())
 	if err != nil {
 		return err
 	}
 
-	// Load the key in the heirarchy
+	// Load the key in the hierarchy
 	err = tpmStore.tpmCommand.runCommand("tpm2_load", "-c", primaryKeyContextPath, "-u", publicKey.Name(), "-r", privateKey.Name(), "-n", nameFile.Name(), "-C", keyContext.Name())
 	if err != nil {
 		return err

--- a/datastore/tpm2manager.go
+++ b/datastore/tpm2manager.go
@@ -50,7 +50,7 @@ func TPM2InitializeKeystore(command TPM20Command) error {
 		return err
 	}
 
-	// Create the primary key in the heirarchy
+	// Create the primary key in the hierarchy
 	err = command.runCommand("tpm2_createprimary", "-A", "o", "-g", algSHA256, "-G", algRSA, "-C", primaryKeyContext.Name())
 	if err != nil {
 		log.Printf("Error in TPM createprimary, %v", err)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+serial-vault (2.1-0ubuntu3) xenial; urgency=medium
+
+  * Testing govendor
+
+ -- Roberto Mier Escandon <roberto.escandon@canonical.com>  Fri, 23 Feb 2018 18:38:14 +0100
+
 serial-vault (2.1-0) xenial; urgency=medium
 
   * Reseller features

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,8 @@ Build-Depends: debhelper (>= 9),
                dh-systemd,
                golang-go,
                bzr,
-               git
+               git,
+               rsync
 Standards-Version: 3.9.6
 Homepage: https://github.com/CanonicalLtd/serial-vault
 Vcs-Browser: https://github.com/CanonicalLtd/serial-vault

--- a/debian/rules
+++ b/debian/rules
@@ -3,9 +3,9 @@
 PROJECT := serial-vault
 export DH_OPTIONS
 export DH_GOPKG := github.com/CanonicalLtd/${PROJECT}
-export GOPATH := ${CURDIR}/_build:/usr/share/gocode
+export GOPATH := ${CURDIR}/_build
 export GOBIN := ${GOPATH}/bin
-export PATH := ${PATH}:${GOBIN}
+export PATH := ${GOBIN}:${PATH}
 BLDPATH := $(shell dpkg-architecture -qDEB_BUILD_GNU_TYPE)
 SRCDIR := ${CURDIR}/_build/src/${DH_GOPKG}
 DESTDIR := ${CURDIR}/debian/${PROJECT}
@@ -19,11 +19,17 @@ CRONDIR := /etc/cron.d
 	dh $@ --buildsystem=golang --with=golang --with=systemd
 
 override_dh_auto_build:
-	go install -v ${DH_GOPKG}/...
+	mkdir -p ${SRCDIR}
+	mkdir -p ${GOBIN}
+	# copy project to local srcdir to build from there
+	rsync -avz --progress --exclude=_build --exclude=obj-${BLDPATH} \
+		--exclude=debian --exclude=webapp-admin/node_modules \
+		--exclude=webapp-user/node_modules . $(SRCDIR)
+	# build go code
+	(cd ${SRCDIR} && go install -v ./...)
 
 override_dh_auto_test:
-	go get -v -t ${DH_GOPKG}/...
-	(cd _build/src/${DH_GOPKG} && ./run-checks)
+	(cd ${SRCDIR} && go test -v ./...)
 
 override_dh_auto_install:
 	mkdir -p ${DESTDIR}/${BINDIR}
@@ -50,5 +56,3 @@ override_dh_auto_clean:
 	dh_clean
 	rm -rf ${CURDIR}/obj-${BLDPATH}
 	rm -rf ${CURDIR}/_build
-
-

--- a/docs/config.md
+++ b/docs/config.md
@@ -13,13 +13,13 @@ The SerialVault will need to be configured for use at the factory. The prime fun
 The configuration will be handled by a web user interface that will be accessible only from 
 the data centre. The following functionality will be provided by the web user interface:
 
- * Adding new private keys and activate/deactivate them
- * Adding a new model and its signing key
- * Revoking a model
- * Listing supported models
- * Displaying the Signing Log of serial numbers and device-keys that have been signed
- * Deleting entries from the Signing Log
- * Displaying the version of the SerialVault
+* Adding new private keys and activate/deactivate them
+* Adding a new model and its signing key
+* Revoking a model
+* Listing supported models
+* Displaying the Signing Log of serial numbers and device-keys that have been signed
+* Deleting entries from the Signing Log
+* Displaying the version of the SerialVault
 
 # Adding a new private signing key
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -9,9 +9,9 @@ table_of_contents: False
 
 The SerialVault is comprised of three services, deployed at a data centre:
 
- * Signing Service
- * Admin Service
- * System-User Service (optional)
+* Signing Service
+* Admin Service
+* System-User Service (optional)
 
 The Signing Service is the publicly accessible service that is used to generate a 
 signed serial assertion using a predefined signing key. The Admin Service is a private 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,8 +18,8 @@ number and device-key fingerprint have been previously used.
 
 The application can operate in two modes:
 
- * Signing: the service for generating signed serial assertions
- * Admin: the service for registering new models and signing keys
+* Signing: the service for generating signed serial assertions
+* Admin: the service for registering new models and signing keys
 
 The Admin and Signing services both operate under unencrypted HTTP connections, so it is 
 left to the deployer to incorporate security measures around the services.

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -9,6 +9,6 @@ The SerialVault will expose a REST API that can be used by the Gadget Snap that 
 
 The following functionality needs to be exposed by the signing service API:
 
- * query version of the vault
- * query supported models
- * request device assertion creation
+* query version of the vault
+* query supported models
+* request device assertion creation

--- a/docs/reference/rest-api/v1-request-id.md
+++ b/docs/reference/rest-api/v1-request-id.md
@@ -34,11 +34,11 @@ api-key: <the_api_key_value>
 
 The following errors can occur:
 
- * Error in retrieving the authentication token
- * The authentication token is invalid
- * Invalid API key used
- * delete-expired-nonces
- * generate-request-id error
+* Error in retrieving the authentication token
+* The authentication token is invalid
+* Invalid API key used
+* delete-expired-nonces
+* generate-request-id error
 
 ### Example
 

--- a/docs/reference/rest-api/v1-serial.md
+++ b/docs/reference/rest-api/v1-serial.md
@@ -36,9 +36,9 @@ see details [here](https://docs.ubuntu.com/core/en/reference/assertions/serial)
 
 The following errors can occur:
 
- * Error in retrieving the authentication token
- * The authentication token is invalid
- * Error encoding the version response
+* Error in retrieving the authentication token
+* The authentication token is invalid
+* Error encoding the version response
 
 ### Example
 

--- a/docs/reference/rest-api/v1-version.md
+++ b/docs/reference/rest-api/v1-version.md
@@ -29,9 +29,9 @@ None
 
 The following errors can occur:
 
- * Error in retrieving the authentication token
- * The authentication token is invalid
- * Error encoding the version response
+* Error in retrieving the authentication token
+* The authentication token is invalid
+* Error encoding the version response
 
 ### Example
 

--- a/docs/snap.md
+++ b/docs/snap.md
@@ -16,9 +16,9 @@ sudo snap install serial-vault
 The service needs a PostgreSQL database instance to run so, you'll also
 need to:
 
- * Install PostgreSQL and create a database
- * Set up the config file, using _settings.yaml_ in this project root folder as guide
- * Configure the snap using the _settings.yaml_ file as input
+* Install PostgreSQL and create a database
+* Set up the config file, using _settings.yaml_ in this project root folder as guide
+* Configure the snap using the _settings.yaml_ file as input
 
  The snap will create or update the tables in the database on restart, as soon as it has
  a valid database connection.

--- a/get-deps.sh
+++ b/get-deps.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -eu
+
+if ! which govendor >/dev/null;then
+    export PATH="$PATH:${GOPATH%%:*}/bin"
+
+    if ! which govendor >/dev/null;then
+	    echo Installing govendor
+	    go get -u github.com/kardianos/govendor
+    fi
+fi
+
+echo Obtaining dependencies
+govendor sync
+
+unused="$(govendor list +unused)"
+if [ "$unused" != "" ]; then
+    echo "Found unused ./vendor packages:"
+    echo "$unused"
+    echo "Please fix via 'govendor remove +unused'"
+    exit 1
+fi

--- a/manage/account_test.go
+++ b/manage/account_test.go
@@ -38,13 +38,13 @@ func (s *AccountSuite) SetUpTest(c *check.C) {
 
 func (s *AccountSuite) TestAccount(c *check.C) {
 	tests := []manTest{
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "account"},
 			ErrorMessage: "Please specify the cache command"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "account", "invalid"},
 			ErrorMessage: "Unknown command `invalid'. You should use the cache command"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "account", "cache"},
 			ErrorMessage: ""},
 	}

--- a/manage/client.go
+++ b/manage/client.go
@@ -72,7 +72,7 @@ func (cmd ClientCommand) generatePrivateKey() (asserts.PrivateKey, error) {
 	encodedSigningKey := base64.StdEncoding.EncodeToString(signingKey)
 
 	privateKey, _, err := crypt.DeserializePrivateKey(encodedSigningKey)
-	return privateKey, nil
+	return privateKey, err
 }
 
 func (cmd ClientCommand) generateSerialRequestAssertion() (string, error) {

--- a/manage/client_test.go
+++ b/manage/client_test.go
@@ -29,10 +29,10 @@ func (s *ClientSuite) SetUpTest(c *check.C) {}
 
 func (s *ClientSuite) TestAccount(c *check.C) {
 	tests := []manTest{
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "client"},
 			ErrorMessage: "the required flags `-a, --api', `-b, --brand', `-m, --model', `-s, --serial' and `-u, --url' were not specified"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "client", "invalid"},
 			ErrorMessage: "the required flags `-a, --api', `-b, --brand', `-m, --model', `-s, --serial' and `-u, --url' were not specified"},
 	}

--- a/manage/database.go
+++ b/manage/database.go
@@ -126,7 +126,7 @@ func updateDatabase() {
 		datastore.Environ.DB.PutKeypair(datastore.Keypair{AuthorityID: "System", KeyID: "61abf588e52be7a3"})
 	}
 
-	// Initalize the TPM store, authenticating with the TPM 2.0 module
+	// Initialize the TPM store, authenticating with the TPM 2.0 module
 	if datastore.Environ.Config.KeyStoreType == datastore.TPM20Store.Name {
 		fmt.Println("Initialize the TPM2.0 store")
 		err := datastore.TPM2InitializeKeystore(nil)

--- a/manage/database_test.go
+++ b/manage/database_test.go
@@ -59,7 +59,7 @@ func (s *databaseSuite) TestDoTable(c *check.C) {
 
 func (s *databaseSuite) TestDatabase(c *check.C) {
 	tests := []manTest{
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "database"},
 			ErrorMessage: ""},
 	}

--- a/manage/user_test.go
+++ b/manage/user_test.go
@@ -34,52 +34,52 @@ func (s *UserSuite) SetUpTest(c *check.C) {
 
 func (s *UserSuite) TestUser(c *check.C) {
 	tests := []manTest{
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user"},
 			ErrorMessage: "Please specify one command of: add, delete, list or update"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "list"},
 			ErrorMessage: ""},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "add"},
 			ErrorMessage: "the required flags `-n, --name' and `-r, --role' were not specified"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "add", "-n"},
 			ErrorMessage: "expected argument for flag `-n, --name'"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "add", "-n", "John Smith", "-r", "invalid"},
 			ErrorMessage: "Invalid value `invalid' for option `-r, --role'. Allowed values are: standard, admin or superuser"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "add", "-n", "John Smith", "-r", "admin"},
 			ErrorMessage: "Add user expects a 'username' argument"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "add", "ddan", "-n", "Desperate Dan", "-r", "admin"},
 			ErrorMessage: ""},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "add", "ddan", "-n", "Desperate Dan", "-r", "admin", "-bad"},
 			ErrorMessage: "unknown flag `b'"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "update"},
 			ErrorMessage: "Update user expects a 'username' argument"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "update", "john", "smith"},
 			ErrorMessage: "Update user expects a single 'username' argument"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "update", "sv"},
 			ErrorMessage: "No changes requested. Please supply user details to change"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "update", "sv", "-n", "Simon Vault"},
 			ErrorMessage: ""},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "update", "sv", "-u", "svault"},
 			ErrorMessage: ""},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "delete"},
 			ErrorMessage: "Delete user expects a 'username' argument"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "delete", "john", "smith"},
 			ErrorMessage: "Delete user expects a single 'username' argument"},
-		manTest{
+		{
 			Args:         []string{"serial-vault-admin", "user", "delete", "sv"},
 			ErrorMessage: ""},
 	}

--- a/mdlint.py
+++ b/mdlint.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+#
+# see http://daringfireball.net/projects/markdown/syntax
+# for the "canonical" reference
+#
+# We support django-markdown which uses python-markdown, see:
+# http://pythonhosted.org/Markdown/
+
+import sys
+import codecs
+
+def lint_li(fname, text):
+    """Ensure that the list-items are multiplies of 4"""
+    is_clean = True
+    for i, line in enumerate(text.splitlines()):
+        if line.lstrip().startswith("*") and line.index("*") % 4 != 0:
+            print("%s: line %i list has non-4 spaces indent" % (fname, i))
+            is_clean = False
+    return is_clean
+
+
+def lint(md_files):
+    """lint all md files"""
+    all_clean = True
+    for md in md_files:
+        with codecs.open(md, "r", "utf-8") as f:
+            buf = f.read()
+            for fname, func in globals().items():
+                if fname.startswith("lint_"):
+                    all_clean &= func(md, buf)
+    return all_clean
+
+
+if __name__ == "__main__":
+    if not lint(sys.argv):
+        sys.exit(1)

--- a/run-checks
+++ b/run-checks
@@ -1,21 +1,37 @@
 #!/bin/sh
+
+if [ "$TRAVIS_BUILD_NUMBER" ]; then
+    echo travis_fold:start:env
+    printenv | sort
+    echo travis_fold:end:env
+fi
+
 export LANG=C.UTF-8
 export LANGUAGE=en
 set -eu
 
-STATIC=""
-UNIT=""
+if which goctest >/dev/null; then
+    goctest="goctest"
+else
+    goctest="go test"
+fi
+COVERMODE=${COVERMODE:-atomic}
+export GOPATH="${GOPATH:-$(realpath "$(dirname "$0")"/../../../../)}"
+export PATH="$PATH:${GOPATH%%:*}/bin"
+
+STATIC=
+UNIT=
 
 case "${1:-all}" in
     all)
-        STATIC="yes"
-        UNIT="yes"
+        STATIC=1
+        UNIT=1
         ;;
     --static)
-        STATIC="yes"
+        STATIC=1
         ;;
     --unit)
-        UNIT="yes"
+        UNIT=1
         ;;
     *)
         echo "Wrong flag ${1}. To run a single suite use --static or --unit"
@@ -47,7 +63,6 @@ endmsg() {
 }
 addtrap endmsg
 
-
 # Append the coverage profile of a package to the project coverage.
 append_coverage() {
     local profile="$1"
@@ -58,59 +73,118 @@ append_coverage() {
 }
 
 
-echo Installing godeps
-go get launchpad.net/godeps
-export PATH=$PATH:$GOPATH/bin
+if [ "$STATIC" = 1 ]; then
+    ./get-deps.sh
 
-echo Obtaining dependencies
-godeps -u dependencies.tsv
-
-if [ ! -z "$STATIC" ]; then
+    # Run static tests.
+    echo Checking docs
+    ./mdlint.py ./*.md docs/*.md docs/reference/*.md docs/reference/rest-api/*.md
 
     echo Checking formatting
-    fmt=$(gofmt -l .)
+    fmt=""
+    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
+        s="$(gofmt -s -l "$dir")"
+        if [ -n "$s" ]; then
+            fmt="$s\n$fmt"
+        fi
+    done
 
     if [ -n "$fmt" ]; then
-        echo "Formatting wrong in following files"
+        echo "Formatting wrong in following files:"
         echo "$fmt"
         exit 1
     fi
 
     # go vet
     echo Running vet
-    go vet ./...
+    go list ./... | grep -v '/vendor/' | xargs go vet
 
     # golint
     echo Install golint
-    go get github.com/golang/lint/golint
-    export PATH=$PATH:$GOPATH/bin
-
+    if ! which golint >/dev/null; then
+        go get github.com/golang/lint/golint
+    fi
+    
     echo Running lint
-    lint=$(golint ./...)
-    if [ -n "$lint" ]; then
-        echo "Lint complains:"
-        echo "$lint"
+    for dir in $(go list -f '{{.Dir}}' ./... | grep -v '/vendor/' ); do
+        lint="$(golint "$dir")"
+        if [ -n "$lint" ]; then
+            echo "Lint complains:"
+            echo "$lint"
+            exit 1
+        fi
+    done
+
+    # TODO: Commented out until desired to fix all the remaining format stuff
+    #
+    # if which shellcheck >/dev/null; then
+    #     echo Checking shell scripts...
+    #     ( git ls-files -z 2>/dev/null ||
+    #             find . \( -name .git -o -name vendor \) -prune -o -print0 ) |
+    #         xargs -0 file -N |
+    #         awk -F": " '$2~/shell.script/{print $1}' |
+    #         xargs shellcheck
+    #     regexp='GOPATH(?!%%:\*)(?!:)[^=]*/'
+    #     if grep -qPr --exclude HACKING.md --exclude-dir .git --exclude-dir vendor "$regexp"; then
+    #         echo "Using GOPATH as if it were a single entry and not a list:"
+    #         grep -PHrn -C1 --color=auto --exclude HACKING.md --exclude-dir .git --exclude-dir vendor "$regexp"
+    #         exit 1
+    #     fi
+    #     unset regexp
+    # fi
+
+    echo Checking spelling errors
+    if ! which misspell >/dev/null; then
+        go get -u github.com/client9/misspell/cmd/misspell
+    fi
+    for file in *; do
+        if [ "$file" = "vendor" ] || [ "$file" = "static" ] || [ "$file" = "webapp-admin" ] || [ "$file" = "webapp-user" ] || [ "$file" = "test" ]; then
+            continue
+        fi
+        misspell -error -i auther,PROCES,PROCESSS,proces,processs,exportfs "$file"
+    done
+
+    echo Checking for ineffective assignments
+    if ! which ineffassign >/dev/null; then
+        go get -u github.com/gordonklaus/ineffassign
+    fi
+    # ineffassign knows about ignoring vendor/ \o/
+    ineffassign .
+
+    echo Checking for naked returns
+    if ! which nakedret >/dev/null; then
+        go get -u github.com/alexkohler/nakedret
+    fi
+    got=$(nakedret ./... 2>&1)
+    if [ -n "$got" ]; then
+        echo "$got"
         exit 1
     fi
-
 fi
 
 if [ ! -z "$UNIT" ]; then
+    ./get-deps.sh
+
     # Prepare the coverage output profile.
     rm -rf .coverage
     mkdir .coverage
-    echo "mode: set" > .coverage/coverage.out
+    echo "mode: $COVERMODE" > .coverage/coverage.out
 
     echo Building
-    go build -v ./...
+    go build -v github.com/CanonicalLtd/serial-vault/...
 
     # tests
-    echo Running tests from $(pwd)
-    for pkg in $(go list ./...); do
-        go test -v -coverprofile=.coverage/profile.out $pkg
+    echo Running tests from "$PWD"
+    for pkg in $(go list ./... | grep -v '/vendor/' ); do
+        go test -i "$pkg"
+        $goctest -v -coverprofile=.coverage/profile.out -covermode="$COVERMODE" "$pkg"
         append_coverage .coverage/profile.out
     done
 
+    # upload to codecov.io if on travis
+    if [ "${TRAVIS_BUILD_NUMBER:-}" ]; then
+        curl -s https://codecov.io/bash | bash /dev/stdin -f .coverage/coverage.out
+    fi
 fi
 
 UNCLEAN="$(git status -s|grep ^??)" || true

--- a/service/handlers_accounts_test.go
+++ b/service/handlers_accounts_test.go
@@ -84,9 +84,9 @@ func (s *AccountSuite) parseBooleanResponse(w *httptest.ResponseRecorder) (Boole
 func (s *AccountSuite) TestAccountsHandler(c *check.C) {
 
 	tests := []AccountTest{
-		AccountTest{"GET", "/v1/accounts", nil, 200, "application/json; charset=UTF-8", 0, false, true, 3},
-		AccountTest{"GET", "/v1/accounts", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 3},
-		AccountTest{"GET", "/v1/accounts", nil, 200, "application/json; charset=UTF-8", 0, true, false, 0},
+		{"GET", "/v1/accounts", nil, 200, "application/json; charset=UTF-8", 0, false, true, 3},
+		{"GET", "/v1/accounts", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 3},
+		{"GET", "/v1/accounts", nil, 200, "application/json; charset=UTF-8", 0, true, false, 0},
 	}
 
 	for _, t := range tests {
@@ -113,18 +113,18 @@ func (s *AccountSuite) TestCreateGetUpdateAccountHandlers(c *check.C) {
 	acc, _ := json.Marshal(account)
 
 	tests := []AccountTest{
-		AccountTest{"POST", "/v1/accounts", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
-		AccountTest{"POST", "/v1/accounts", acc, 200, "application/json; charset=UTF-8", 0, false, true, 0},
-		AccountTest{"POST", "/v1/accounts", acc, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 1},
-		AccountTest{"POST", "/v1/accounts", acc, 200, "application/json; charset=UTF-8", 0, true, false, 0},
-		AccountTest{"GET", "/v1/accounts/99999", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
-		AccountTest{"GET", "/v1/accounts/1", nil, 200, "application/json; charset=UTF-8", 0, false, true, 0},
-		AccountTest{"GET", "/v1/accounts/1", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 0},
-		AccountTest{"GET", "/v1/accounts/1", nil, 200, "application/json; charset=UTF-8", 0, true, false, 0},
-		AccountTest{"PUT", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
-		AccountTest{"PUT", "/v1/accounts/1", acc, 200, "application/json; charset=UTF-8", 0, false, true, 0},
-		AccountTest{"PUT", "/v1/accounts/1", acc, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 0},
-		AccountTest{"PUT", "/v1/accounts/1", acc, 200, "application/json; charset=UTF-8", 0, true, false, 0},
+		{"POST", "/v1/accounts", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
+		{"POST", "/v1/accounts", acc, 200, "application/json; charset=UTF-8", 0, false, true, 0},
+		{"POST", "/v1/accounts", acc, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 1},
+		{"POST", "/v1/accounts", acc, 200, "application/json; charset=UTF-8", 0, true, false, 0},
+		{"GET", "/v1/accounts/99999", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
+		{"GET", "/v1/accounts/1", nil, 200, "application/json; charset=UTF-8", 0, false, true, 0},
+		{"GET", "/v1/accounts/1", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 0},
+		{"GET", "/v1/accounts/1", nil, 200, "application/json; charset=UTF-8", 0, true, false, 0},
+		{"PUT", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
+		{"PUT", "/v1/accounts/1", acc, 200, "application/json; charset=UTF-8", 0, false, true, 0},
+		{"PUT", "/v1/accounts/1", acc, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 0},
+		{"PUT", "/v1/accounts/1", acc, 200, "application/json; charset=UTF-8", 0, true, false, 0},
 	}
 
 	for _, t := range tests {

--- a/service/handlers_assertion_test.go
+++ b/service/handlers_assertion_test.go
@@ -69,13 +69,13 @@ func (s *AssertionSuite) sendRequest(method, url string, data io.Reader, apiKey 
 
 func (s *AssertionSuite) TestAssertionHandler(c *check.C) {
 	tests := []AssertionTest{
-		AssertionTest{nil, 400, jsonType, "ValidAPIKey"},
-		AssertionTest{[]byte{}, 400, jsonType, "ValidAPIKey"},
-		AssertionTest{validModel(), 200, asserts.MediaType, "ValidAPIKey"},
-		AssertionTest{validModel(), 400, jsonType, "InvalidAPIKey"},
-		AssertionTest{invalidModel(), 400, jsonType, "ValidAPIKey"},
-		AssertionTest{unauthBrand(), 400, jsonType, "ValidAPIKey"},
-		AssertionTest{unknownBrand(), 400, jsonType, "ValidAPIKey"},
+		{nil, 400, jsonType, "ValidAPIKey"},
+		{[]byte{}, 400, jsonType, "ValidAPIKey"},
+		{validModel(), 200, asserts.MediaType, "ValidAPIKey"},
+		{validModel(), 400, jsonType, "InvalidAPIKey"},
+		{invalidModel(), 400, jsonType, "ValidAPIKey"},
+		{unauthBrand(), 400, jsonType, "ValidAPIKey"},
+		{unknownBrand(), 400, jsonType, "ValidAPIKey"},
 	}
 
 	for _, t := range tests {

--- a/service/handlers_models_test.go
+++ b/service/handlers_models_test.go
@@ -106,6 +106,7 @@ func (s *ModelsSuite) TestModelsHandler(c *check.C) {
 	c.Assert(w.Code, check.Equals, 200)
 
 	result, err := s.parseModelsResponse(w)
+	c.Assert(err, check.IsNil)
 	c.Assert(result.Success, check.Equals, true)
 	c.Assert(len(result.Models), check.Equals, 6)
 	c.Assert(result.Models[0].Name, check.Equals, "alder")
@@ -117,6 +118,7 @@ func (s *ModelsSuite) TestModelsHandlerWithPermissions(c *check.C) {
 	c.Assert(w.Code, check.Equals, 200)
 
 	result, err := s.parseModelsResponse(w)
+	c.Assert(err, check.IsNil)
 	c.Assert(result.Success, check.Equals, true)
 	c.Assert(len(result.Models), check.Equals, 3)
 	c.Assert(result.Models[0].Name, check.Equals, "alder")
@@ -128,6 +130,7 @@ func (s *ModelsSuite) TestModelsHandlerWithoutPermissions(c *check.C) {
 	c.Assert(w.Code, check.Equals, 200)
 
 	result, err := s.parseModelsResponse(w)
+	c.Assert(err, check.IsNil)
 	c.Assert(result.Success, check.Equals, false)
 	c.Assert(result.ErrorCode, check.Equals, "error-auth")
 }
@@ -141,6 +144,7 @@ func (s *ModelsSuite) TestModelsHandlerWithError(c *check.C) {
 	c.Assert(w.Code, check.Equals, 400)
 
 	result, err := s.parseModelsResponse(w)
+	c.Assert(err, check.IsNil)
 	c.Assert(result.Success, check.Equals, false)
 }
 

--- a/service/handlers_pivot_test.go
+++ b/service/handlers_pivot_test.go
@@ -128,12 +128,12 @@ func (s *PivotSuite) SetUpTest(c *check.C) {
 func (s *PivotSuite) TestPivotModelHandler(c *check.C) {
 
 	tests := []PivotTest{
-		PivotTest{"POST", "/v1/pivot", nil, 400, jsonType, "ValidAPIKey", false},
-		PivotTest{"POST", "/v1/pivot", []byte{}, 400, jsonType, "ValidAPIKey", false},
-		PivotTest{"POST", "/v1/pivot", []byte("invalid"), 400, jsonType, "ValidAPIKey", false},
-		PivotTest{"POST", "/v1/pivot", []byte(serialAssert), 200, jsonType, "ValidAPIKey", true},
-		PivotTest{"POST", "/v1/pivot", []byte(serialAssert), 400, jsonType, "InvalidAPIKey", false},
-		PivotTest{"POST", "/v1/pivot", []byte(serialAssertInvalid), 400, jsonType, "ValidAPIKey", false},
+		{"POST", "/v1/pivot", nil, 400, jsonType, "ValidAPIKey", false},
+		{"POST", "/v1/pivot", []byte{}, 400, jsonType, "ValidAPIKey", false},
+		{"POST", "/v1/pivot", []byte("invalid"), 400, jsonType, "ValidAPIKey", false},
+		{"POST", "/v1/pivot", []byte(serialAssert), 200, jsonType, "ValidAPIKey", true},
+		{"POST", "/v1/pivot", []byte(serialAssert), 400, jsonType, "InvalidAPIKey", false},
+		{"POST", "/v1/pivot", []byte(serialAssertInvalid), 400, jsonType, "ValidAPIKey", false},
 	}
 
 	for _, t := range tests {
@@ -151,18 +151,18 @@ func (s *PivotSuite) TestPivotModelHandler(c *check.C) {
 func (s *PivotSuite) TestPivotModelSerialAssertionHandler(c *check.C) {
 
 	tests := []PivotTest{
-		PivotTest{"POST", "/v1/pivotmodel", nil, 400, jsonType, "ValidAPIKey", false},
-		PivotTest{"POST", "/v1/pivotmodel", []byte{}, 400, jsonType, "ValidAPIKey", false},
-		PivotTest{"POST", "/v1/pivotmodel", []byte("invalid"), 400, jsonType, "ValidAPIKey", false},
-		PivotTest{"POST", "/v1/pivotmodel", []byte(serialAssert), 200, asserts.MediaType, "ValidAPIKey", true},
-		PivotTest{"POST", "/v1/pivotmodel", []byte(serialAssert), 400, jsonType, "InvalidAPIKey", false},
-		PivotTest{"POST", "/v1/pivotmodel", []byte(serialAssertInvalid), 400, jsonType, "ValidAPIKey", false},
-		PivotTest{"POST", "/v1/pivotserial", nil, 400, jsonType, "ValidAPIKey", false},
-		PivotTest{"POST", "/v1/pivotserial", []byte{}, 400, jsonType, "ValidAPIKey", false},
-		PivotTest{"POST", "/v1/pivotserial", []byte("invalid"), 400, jsonType, "ValidAPIKey", false},
-		PivotTest{"POST", "/v1/pivotserial", []byte(serialAssert), 200, asserts.MediaType, "ValidAPIKey", true},
-		PivotTest{"POST", "/v1/pivotserial", []byte(serialAssert), 400, jsonType, "InvalidAPIKey", false},
-		PivotTest{"POST", "/v1/pivotserial", []byte(serialAssertInvalid), 400, jsonType, "ValidAPIKey", false},
+		{"POST", "/v1/pivotmodel", nil, 400, jsonType, "ValidAPIKey", false},
+		{"POST", "/v1/pivotmodel", []byte{}, 400, jsonType, "ValidAPIKey", false},
+		{"POST", "/v1/pivotmodel", []byte("invalid"), 400, jsonType, "ValidAPIKey", false},
+		{"POST", "/v1/pivotmodel", []byte(serialAssert), 200, asserts.MediaType, "ValidAPIKey", true},
+		{"POST", "/v1/pivotmodel", []byte(serialAssert), 400, jsonType, "InvalidAPIKey", false},
+		{"POST", "/v1/pivotmodel", []byte(serialAssertInvalid), 400, jsonType, "ValidAPIKey", false},
+		{"POST", "/v1/pivotserial", nil, 400, jsonType, "ValidAPIKey", false},
+		{"POST", "/v1/pivotserial", []byte{}, 400, jsonType, "ValidAPIKey", false},
+		{"POST", "/v1/pivotserial", []byte("invalid"), 400, jsonType, "ValidAPIKey", false},
+		{"POST", "/v1/pivotserial", []byte(serialAssert), 200, asserts.MediaType, "ValidAPIKey", true},
+		{"POST", "/v1/pivotserial", []byte(serialAssert), 400, jsonType, "InvalidAPIKey", false},
+		{"POST", "/v1/pivotserial", []byte(serialAssertInvalid), 400, jsonType, "ValidAPIKey", false},
 	}
 
 	for _, t := range tests {

--- a/service/handlers_store_test.go
+++ b/service/handlers_store_test.go
@@ -68,8 +68,8 @@ func (s *StoreSuite) sendRequest(method, url string, data io.Reader, c *check.C)
 
 func (s *StoreSuite) TestStoreHandler(c *check.C) {
 	tests := []StoreSuiteTest{
-		StoreSuiteTest{nil, 400},
-		StoreSuiteTest{validKeyRegister(), 200},
+		{nil, 400},
+		{validKeyRegister(), 200},
 	}
 
 	for _, t := range tests {

--- a/service/handlers_substore_test.go
+++ b/service/handlers_substore_test.go
@@ -101,9 +101,9 @@ func (s *SubstoreSuite) parseBooleanResponse(w *httptest.ResponseRecorder) (Bool
 
 func (s *SubstoreSuite) TestSubstoresHandler(c *check.C) {
 	tests := []SubstoreTest{
-		SubstoreTest{"GET", "/v1/accounts/1/stores", nil, 200, "application/json; charset=UTF-8", 0, false, true, 2},
-		SubstoreTest{"GET", "/v1/accounts/1/stores", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 2},
-		SubstoreTest{"GET", "/v1/accounts/1/stores", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
+		{"GET", "/v1/accounts/1/stores", nil, 200, "application/json; charset=UTF-8", 0, false, true, 2},
+		{"GET", "/v1/accounts/1/stores", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 2},
+		{"GET", "/v1/accounts/1/stores", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
 	}
 
 	for _, t := range tests {
@@ -132,17 +132,17 @@ func (s *SubstoreSuite) TestSubstoresCreateUpdateDeleteHandler(c *check.C) {
 	ss, _ := json.Marshal(substore)
 
 	tests := []SubstoreTest{
-		SubstoreTest{"POST", "/v1/accounts/stores", ssn, 200, "application/json; charset=UTF-8", 0, false, true, 0},
-		SubstoreTest{"POST", "/v1/accounts/stores", ssn, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 0},
-		SubstoreTest{"POST", "/v1/accounts/stores", ssn, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
-		SubstoreTest{"POST", "/v1/accounts/stores", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
-		SubstoreTest{"PUT", "/v1/accounts/stores/1", ss, 200, "application/json; charset=UTF-8", 0, false, true, 0},
-		SubstoreTest{"PUT", "/v1/accounts/stores/1", ss, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 0},
-		SubstoreTest{"PUT", "/v1/accounts/stores/1", ss, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
-		SubstoreTest{"PUT", "/v1/accounts/stores/1", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
-		SubstoreTest{"DELETE", "/v1/accounts/stores/1", nil, 200, "application/json; charset=UTF-8", 0, false, true, 0},
-		SubstoreTest{"DELETE", "/v1/accounts/stores/1", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 0},
-		SubstoreTest{"DELETE", "/v1/accounts/stores/1", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
+		{"POST", "/v1/accounts/stores", ssn, 200, "application/json; charset=UTF-8", 0, false, true, 0},
+		{"POST", "/v1/accounts/stores", ssn, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 0},
+		{"POST", "/v1/accounts/stores", ssn, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
+		{"POST", "/v1/accounts/stores", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
+		{"PUT", "/v1/accounts/stores/1", ss, 200, "application/json; charset=UTF-8", 0, false, true, 0},
+		{"PUT", "/v1/accounts/stores/1", ss, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 0},
+		{"PUT", "/v1/accounts/stores/1", ss, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
+		{"PUT", "/v1/accounts/stores/1", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
+		{"DELETE", "/v1/accounts/stores/1", nil, 200, "application/json; charset=UTF-8", 0, false, true, 0},
+		{"DELETE", "/v1/accounts/stores/1", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 0},
+		{"DELETE", "/v1/accounts/stores/1", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
 	}
 
 	for _, t := range tests {
@@ -167,9 +167,9 @@ func (s *SubstoreSuite) TestSubstoresErrorHandler(c *check.C) {
 	datastore.Environ.DB = &datastore.ErrorMockDB{}
 
 	tests := []SubstoreTest{
-		SubstoreTest{"GET", "/v1/accounts/1/stores", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
-		SubstoreTest{"GET", "/v1/accounts/1/stores", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
-		SubstoreTest{"GET", "/v1/accounts/1/stores", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
+		{"GET", "/v1/accounts/1/stores", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
+		{"GET", "/v1/accounts/1/stores", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
+		{"GET", "/v1/accounts/1/stores", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
 	}
 
 	for _, t := range tests {
@@ -200,17 +200,17 @@ func (s *SubstoreSuite) TestSubstoresUpdateErrorHandler(c *check.C) {
 	ss, _ := json.Marshal(substore)
 
 	tests := []SubstoreTest{
-		SubstoreTest{"POST", "/v1/accounts/stores", ssn, 400, "application/json; charset=UTF-8", 0, false, false, 0},
-		SubstoreTest{"POST", "/v1/accounts/stores", ssn, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
-		SubstoreTest{"POST", "/v1/accounts/stores", ssn, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
-		SubstoreTest{"POST", "/v1/accounts/stores", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
-		SubstoreTest{"PUT", "/v1/accounts/stores/1", ss, 400, "application/json; charset=UTF-8", 0, false, false, 0},
-		SubstoreTest{"PUT", "/v1/accounts/stores/1", ss, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
-		SubstoreTest{"PUT", "/v1/accounts/stores/1", ss, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
-		SubstoreTest{"PUT", "/v1/accounts/stores/1", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
-		SubstoreTest{"DELETE", "/v1/accounts/stores/1", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
-		SubstoreTest{"DELETE", "/v1/accounts/stores/1", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
-		SubstoreTest{"DELETE", "/v1/accounts/stores/1", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
+		{"POST", "/v1/accounts/stores", ssn, 400, "application/json; charset=UTF-8", 0, false, false, 0},
+		{"POST", "/v1/accounts/stores", ssn, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
+		{"POST", "/v1/accounts/stores", ssn, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
+		{"POST", "/v1/accounts/stores", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
+		{"PUT", "/v1/accounts/stores/1", ss, 400, "application/json; charset=UTF-8", 0, false, false, 0},
+		{"PUT", "/v1/accounts/stores/1", ss, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
+		{"PUT", "/v1/accounts/stores/1", ss, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
+		{"PUT", "/v1/accounts/stores/1", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
+		{"DELETE", "/v1/accounts/stores/1", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
+		{"DELETE", "/v1/accounts/stores/1", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
+		{"DELETE", "/v1/accounts/stores/1", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
 	}
 
 	for _, t := range tests {

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -48,7 +48,7 @@ func generatePrivateKey() (asserts.PrivateKey, error) {
 	encodedSigningKey := base64.StdEncoding.EncodeToString(signingKey)
 
 	privateKey, _, err := crypt.DeserializePrivateKey(encodedSigningKey)
-	return privateKey, nil
+	return privateKey, err
 }
 
 func generateSerialRequestAssertion(model, serial, body string) (string, error) {

--- a/service/keypair/handlers_adminapi_test.go
+++ b/service/keypair/handlers_adminapi_test.go
@@ -33,10 +33,10 @@ import (
 func (s *KeypairSuite) TestAPIKeypairsHandler(c *check.C) {
 
 	tests := []KeypairTest{
-		KeypairTest{"GET", "/api/keypairs", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
-		KeypairTest{"GET", "/api/keypairs", nil, 200, "application/json; charset=UTF-8", datastore.Admin, false, true, 2},
-		KeypairTest{"GET", "/api/keypairs", nil, 400, "application/json; charset=UTF-8", datastore.Standard, false, false, 0},
-		KeypairTest{"GET", "/api/keypairs", nil, 400, "application/json; charset=UTF-8", 0, true, false, 0},
+		{"GET", "/api/keypairs", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
+		{"GET", "/api/keypairs", nil, 200, "application/json; charset=UTF-8", datastore.Admin, false, true, 2},
+		{"GET", "/api/keypairs", nil, 400, "application/json; charset=UTF-8", datastore.Standard, false, false, 0},
+		{"GET", "/api/keypairs", nil, 400, "application/json; charset=UTF-8", 0, true, false, 0},
 	}
 
 	for _, t := range tests {

--- a/service/keypair/handlers_keypairs_test.go
+++ b/service/keypair/handlers_keypairs_test.go
@@ -67,10 +67,10 @@ func (s *KeypairSuite) SetUpTest(c *check.C) {
 
 func (s *KeypairSuite) TestKeypairsHandler(c *check.C) {
 	tests := []KeypairTest{
-		KeypairTest{"GET", "/v1/keypairs", nil, 200, "application/json; charset=UTF-8", 0, false, true, 4},
-		KeypairTest{"GET", "/v1/keypairs", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 2},
-		KeypairTest{"GET", "/v1/keypairs", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
-		KeypairTest{"GET", "/v1/keypairs", nil, 400, "application/json; charset=UTF-8", 0, true, false, 0},
+		{"GET", "/v1/keypairs", nil, 200, "application/json; charset=UTF-8", 0, false, true, 4},
+		{"GET", "/v1/keypairs", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 2},
+		{"GET", "/v1/keypairs", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
+		{"GET", "/v1/keypairs", nil, 400, "application/json; charset=UTF-8", 0, true, false, 0},
 	}
 
 	for _, t := range tests {
@@ -94,8 +94,8 @@ func (s *KeypairSuite) TestKeypairsHandler(c *check.C) {
 func (s *KeypairSuite) TestKeypairsErrorHandler(c *check.C) {
 	datastore.Environ.DB = &datastore.ErrorMockDB{}
 	tests := []KeypairTest{
-		KeypairTest{"GET", "/v1/keypairs", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
-		KeypairTest{"GET", "/v1/keypairs", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
+		{"GET", "/v1/keypairs", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
+		{"GET", "/v1/keypairs", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
 	}
 
 	for _, t := range tests {

--- a/service/signinglog/handlers_adminapi_test.go
+++ b/service/signinglog/handlers_adminapi_test.go
@@ -33,10 +33,10 @@ import (
 func (s *SigningLogSuite) TestAPISigningLogHandler(c *check.C) {
 
 	tests := []SigningLogTest{
-		SigningLogTest{"GET", "/api/signinglog", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
-		SigningLogTest{"GET", "/api/signinglog", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 4},
-		SigningLogTest{"GET", "/api/signinglog", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
-		SigningLogTest{"GET", "/api/signinglog", nil, 400, "application/json; charset=UTF-8", 0, true, false, 0},
+		{"GET", "/api/signinglog", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
+		{"GET", "/api/signinglog", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 4},
+		{"GET", "/api/signinglog", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
+		{"GET", "/api/signinglog", nil, 400, "application/json; charset=UTF-8", 0, true, false, 0},
 	}
 
 	for _, t := range tests {

--- a/service/signinglog/handlers_signinglog_test.go
+++ b/service/signinglog/handlers_signinglog_test.go
@@ -67,10 +67,10 @@ func (s *SigningLogSuite) SetUpTest(c *check.C) {
 
 func (s *SigningLogSuite) TestSigningLogHandler(c *check.C) {
 	tests := []SigningLogTest{
-		SigningLogTest{"GET", "/v1/signinglog", nil, 200, "application/json; charset=UTF-8", 0, false, true, 10},
-		SigningLogTest{"GET", "/v1/signinglog", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 4},
-		SigningLogTest{"GET", "/v1/signinglog", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
-		SigningLogTest{"GET", "/v1/signinglog", nil, 400, "application/json; charset=UTF-8", 0, true, false, 0},
+		{"GET", "/v1/signinglog", nil, 200, "application/json; charset=UTF-8", 0, false, true, 10},
+		{"GET", "/v1/signinglog", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, 4},
+		{"GET", "/v1/signinglog", nil, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, 0},
+		{"GET", "/v1/signinglog", nil, 400, "application/json; charset=UTF-8", 0, true, false, 0},
 	}
 
 	for _, t := range tests {
@@ -94,8 +94,8 @@ func (s *SigningLogSuite) TestSigningLogHandler(c *check.C) {
 func (s *SigningLogSuite) TestSigningLogErrorHandler(c *check.C) {
 	datastore.Environ.DB = &datastore.ErrorMockDB{}
 	tests := []SigningLogTest{
-		SigningLogTest{"GET", "/v1/signinglog", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
-		SigningLogTest{"GET", "/v1/signinglog", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
+		{"GET", "/v1/signinglog", nil, 400, "application/json; charset=UTF-8", 0, false, false, 0},
+		{"GET", "/v1/signinglog", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, 0},
 	}
 
 	for _, t := range tests {

--- a/store/store.go
+++ b/store/store.go
@@ -282,6 +282,9 @@ func requestDischargeMacaroon(endpoint string, data map[string]string) (string, 
 
 	responseData := Discharge{}
 	err = json.NewDecoder(resp.Body).Decode(&responseData)
+	if err != nil {
+		return "", fmt.Errorf(errorPrefix+"%v", err)
+	}
 
 	if responseData.Macaroon == "" {
 		return "", fmt.Errorf(errorPrefix + "empty macaroon returned")

--- a/tests/lib/utilities.sh
+++ b/tests/lib/utilities.sh
@@ -29,7 +29,7 @@ wait_for_systemd_service() {
   #   $systemctl show THE_SERVICE -p StartLimitInterval,StartLimitBurst
   #
   if [ $# -ge 2 ]; then
-    start_limit_interval = $2
+    start_limit_interval=$2
   else
     start_limit_interval=$(systemctl show $1 -p StartLimitInterval | sed 's/StartLimitInterval=//')
     # original limit interval is provided in microseconds.
@@ -37,7 +37,7 @@ wait_for_systemd_service() {
   fi
 
   if [ $# -eq 3 ]; then
-    start_limit_burst = $3
+    start_limit_burst=$3
   else
     start_limit_burst=$(systemctl show $1 -p StartLimitBurst | sed 's/StartLimitBurst=//')
   fi

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,385 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "D37uI+U+FYvTJIdG2TTozXe7i7U=",
+			"path": "github.com/dgrijalva/jwt-go",
+			"revision": "d2709f9f1f31ebcda9651b03077758c1f3a0018c",
+			"revisionTime": "2016-06-16T19:15:56Z"
+		},
+		{
+			"checksumSHA1": "iIUYZyoanCQQTUaWsu8b+iOSPt4=",
+			"path": "github.com/gorilla/context",
+			"revision": "50c25fb3b2b3b3cc724e9b6ac75fb44b3bccd0da",
+			"revisionTime": "2014-11-26T16:33:37Z"
+		},
+		{
+			"checksumSHA1": "2ieXR7YGRBDmQWVeUpjk5ay8iCE=",
+			"path": "github.com/gorilla/csrf",
+			"revision": "69581736821c33d85bbf378f42f6ad864dbd85de",
+			"revisionTime": "2016-11-22T16:45:00Z"
+		},
+		{
+			"checksumSHA1": "6/9VW/AyJyjRXLu+nbhqGYvOO2k=",
+			"path": "github.com/gorilla/handlers",
+			"revision": "a5775781a543af3c6b9f5baf10995e4d14168950",
+			"revisionTime": "2016-08-16T18:47:29Z"
+		},
+		{
+			"checksumSHA1": "ATHl/KcmYOhmdeKcpTh7fb4chgI=",
+			"path": "github.com/gorilla/mux",
+			"revision": "e444e69cbd2e2e3e0749a2f3c717cec491552bbf",
+			"revisionTime": "2014-09-26T15:38:14Z"
+		},
+		{
+			"checksumSHA1": "veX5bpYOBjZZWMyWxXxys8EH9d8=",
+			"path": "github.com/gorilla/securecookie",
+			"revision": "fa5329f913702981df43dcb2a380bac429c810b5",
+			"revisionTime": "2016-10-03T05:16:01Z"
+		},
+		{
+			"checksumSHA1": "Ihm00CfTHuuTYXgXJkgH7TFP0L4=",
+			"path": "github.com/jessevdk/go-flags",
+			"revision": "96dc06278ce32a0e9d957d590bb987c81ee66407",
+			"revisionTime": "2017-07-20T12:40:56Z"
+		},
+		{
+			"checksumSHA1": "PhePgEFH4EzgxUjidWowErmgr0o=",
+			"path": "github.com/juju/usso",
+			"revision": "5b79b358f4bb6735c1b00f6ad051c07c1a1a03e9",
+			"revisionTime": "2016-04-18T12:10:39Z"
+		},
+		{
+			"checksumSHA1": "8xu/03rrnz9BE0mZCENdPqvys7U=",
+			"path": "github.com/juju/usso/openid",
+			"revision": "5b79b358f4bb6735c1b00f6ad051c07c1a1a03e9",
+			"revisionTime": "2016-04-18T12:10:39Z"
+		},
+		{
+			"checksumSHA1": "dNYxHiBLalTqluak2/Z8c3RsSEM=",
+			"path": "github.com/lib/pq",
+			"revision": "50761b0867bd1d9d069276790bcd4a3bccf2324a",
+			"revisionTime": "2016-08-31T22:25:20Z"
+		},
+		{
+			"checksumSHA1": "KzsJ/GkPEyvxG8eBcKrHRFoPhzU=",
+			"path": "github.com/lib/pq/oid",
+			"revision": "50761b0867bd1d9d069276790bcd4a3bccf2324a",
+			"revisionTime": "2016-08-31T22:25:20Z"
+		},
+		{
+			"checksumSHA1": "nV76VgoCpwa+JjK/tSyu5jCj8HQ=",
+			"path": "github.com/ojii/gettext.go",
+			"revision": "b6dae1d7af8a8441285e42661565760b530a8a57",
+			"revisionTime": "2017-01-20T06:14:37Z"
+		},
+		{
+			"checksumSHA1": "j5FytTwC2nAqSrDR7V7O7E4cHKM=",
+			"path": "github.com/ojii/gettext.go/pluralforms",
+			"revision": "b6dae1d7af8a8441285e42661565760b530a8a57",
+			"revisionTime": "2017-01-20T06:14:37Z"
+		},
+		{
+			"checksumSHA1": "ynJSWoF6v+3zMnh9R0QmmG6iGV8=",
+			"path": "github.com/pkg/errors",
+			"revision": "248dadf4e9068a0b3e79f02ed0a610d935de5302",
+			"revisionTime": "2016-10-29T09:36:37Z"
+		},
+		{
+			"checksumSHA1": "XIMaXfW7l9qmmrObEnlbGYEZirQ=",
+			"path": "github.com/snapcore/snapd/arch",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "cNLsTel29ANkvto/p2Qy1H+JMUk=",
+			"path": "github.com/snapcore/snapd/asserts",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "BnmsqbETfx6ou54dyF6KqIPJapI=",
+			"path": "github.com/snapcore/snapd/asserts/sysdb",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "/TL6oo8qYYXfiLNvE5ZOBNvAP2E=",
+			"path": "github.com/snapcore/snapd/asserts/systestkeys",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "ZByKmnihWaPWCPXETbdQy1alssM=",
+			"path": "github.com/snapcore/snapd/dirs",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "l5uz5ZSU1sbhcRpslWj3bagiQfI=",
+			"path": "github.com/snapcore/snapd/httputil",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "sx+Cu+12aBJ7+R01mvtLUbD8Rt4=",
+			"path": "github.com/snapcore/snapd/i18n",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "bEMTWOSV80NXuZ4Kmg2whzC+ZP8=",
+			"path": "github.com/snapcore/snapd/jsonutil",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "A7smbHTL7nkh4FIspK3hXV5TPTM=",
+			"path": "github.com/snapcore/snapd/logger",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "Ln1QetHbtP5QFJD5lk2Z0HEABIs=",
+			"path": "github.com/snapcore/snapd/osutil",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "roA89ImjkpsslVpcjOfhWuAR2FQ=",
+			"path": "github.com/snapcore/snapd/osutil/sys",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "gfHhsonttRP4t6A6PhszjeUNWlE=",
+			"path": "github.com/snapcore/snapd/overlord/auth",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "mJaya27/eWQ/8/8XIvAVJ02BkL8=",
+			"path": "github.com/snapcore/snapd/overlord/configstate/config",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "vkoU0A8zug6BhNqXN2gH3vp6HNw=",
+			"path": "github.com/snapcore/snapd/overlord/state",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "N9AQhrj5Z/GelRX24RmbpWc4G1o=",
+			"path": "github.com/snapcore/snapd/progress",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "lQdju1QFX+zC7y6u+UfXzX9MQVw=",
+			"path": "github.com/snapcore/snapd/release",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "KJOuTM6+k2xit/Ph4fPB9NtkXL4=",
+			"path": "github.com/snapcore/snapd/snap",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "fG0pgHM5bCVJJY4UYfmsKhLOx54=",
+			"path": "github.com/snapcore/snapd/snap/snapdir",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "PgDjSnvUM0KhjnYhqAQxz6Avr5I=",
+			"path": "github.com/snapcore/snapd/snap/squashfs",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "SJ2TDJksphfJ9x5TBucAPtTuWgk=",
+			"path": "github.com/snapcore/snapd/spdx",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "bF68Bz49VDaTMg0mSySCTg4psTs=",
+			"path": "github.com/snapcore/snapd/store",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "IgM7/6vR1SY9M78aVDnk3wLm/Fs=",
+			"path": "github.com/snapcore/snapd/strutil",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "QtnO3LTYo8uSO2bPSZD0DxGbLwM=",
+			"path": "github.com/snapcore/snapd/strutil/quantity",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "leL+WTjj2xj4V+wbm76CXw2Eo/c=",
+			"path": "github.com/snapcore/snapd/timeout",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "K+BrNmSQcG6VKAxHBamXap49Ilw=",
+			"path": "github.com/snapcore/snapd/timeutil",
+			"revision": "17ab2545057250006c2feb5a658732b78681fd8c",
+			"revisionTime": "2018-02-23T16:28:32Z"
+		},
+		{
+			"checksumSHA1": "8RSQDPLdGNV6q4jiM+OEoN41wgw=",
+			"path": "github.com/yohcop/openid-go",
+			"revision": "f38c0087a377532505cb5b86418b1cc50d385f0d",
+			"revisionTime": "2016-03-04T16:44:25Z"
+		},
+		{
+			"checksumSHA1": "TT1rac6kpQp2vz24m5yDGUNQ/QQ=",
+			"path": "golang.org/x/crypto/cast5",
+			"revision": "432090b8f568c018896cd8a0fb0345872bbac6ce",
+			"revisionTime": "2018-02-08T00:33:17Z"
+		},
+		{
+			"checksumSHA1": "TwxAhBcGuCzWA6H3FvJE1XVZsxo=",
+			"path": "golang.org/x/crypto/nacl/secretbox",
+			"revision": "432090b8f568c018896cd8a0fb0345872bbac6ce",
+			"revisionTime": "2018-02-08T00:33:17Z"
+		},
+		{
+			"checksumSHA1": "olOKkhrdkYQHZ0lf1orrFQPQrv4=",
+			"path": "golang.org/x/crypto/openpgp/armor",
+			"revision": "432090b8f568c018896cd8a0fb0345872bbac6ce",
+			"revisionTime": "2018-02-08T00:33:17Z"
+		},
+		{
+			"checksumSHA1": "eo/KtdjieJQXH7Qy+faXFcF70ME=",
+			"path": "golang.org/x/crypto/openpgp/elgamal",
+			"revision": "432090b8f568c018896cd8a0fb0345872bbac6ce",
+			"revisionTime": "2018-02-08T00:33:17Z"
+		},
+		{
+			"checksumSHA1": "rlxVSaGgqdAgwblsErxTxIfuGfg=",
+			"path": "golang.org/x/crypto/openpgp/errors",
+			"revision": "432090b8f568c018896cd8a0fb0345872bbac6ce",
+			"revisionTime": "2018-02-08T00:33:17Z"
+		},
+		{
+			"checksumSHA1": "Pq88+Dgh04UdXWZN6P+bLgYnbRc=",
+			"path": "golang.org/x/crypto/openpgp/packet",
+			"revision": "432090b8f568c018896cd8a0fb0345872bbac6ce",
+			"revisionTime": "2018-02-08T00:33:17Z"
+		},
+		{
+			"checksumSHA1": "s2qT4UwvzBSkzXuiuMkowif1Olw=",
+			"path": "golang.org/x/crypto/openpgp/s2k",
+			"revision": "432090b8f568c018896cd8a0fb0345872bbac6ce",
+			"revisionTime": "2018-02-08T00:33:17Z"
+		},
+		{
+			"checksumSHA1": "kVKE0OX1Xdw5mG7XKT86DLLKE2I=",
+			"path": "golang.org/x/crypto/poly1305",
+			"revision": "432090b8f568c018896cd8a0fb0345872bbac6ce",
+			"revisionTime": "2018-02-08T00:33:17Z"
+		},
+		{
+			"checksumSHA1": "cRCpfAgTnlIDpdcfjivbiv+9YJU=",
+			"path": "golang.org/x/crypto/salsa20/salsa",
+			"revision": "432090b8f568c018896cd8a0fb0345872bbac6ce",
+			"revisionTime": "2018-02-08T00:33:17Z"
+		},
+		{
+			"checksumSHA1": "iNE2KX9BQzCptlQC2DdQEVmn4R4=",
+			"path": "golang.org/x/crypto/sha3",
+			"revision": "432090b8f568c018896cd8a0fb0345872bbac6ce",
+			"revisionTime": "2018-02-08T00:33:17Z"
+		},
+		{
+			"checksumSHA1": "6U7dCaxxIMjf5V02iWgyAwppczw=",
+			"path": "golang.org/x/crypto/ssh/terminal",
+			"revision": "432090b8f568c018896cd8a0fb0345872bbac6ce",
+			"revisionTime": "2018-02-08T00:33:17Z"
+		},
+		{
+			"checksumSHA1": "Y+HGqEkYM15ir+J93MEaHdyFy0c=",
+			"path": "golang.org/x/net/context",
+			"revision": "ffcf1bedda3b04ebb15a168a59800a73d6dc0f4d",
+			"revisionTime": "2017-03-29T01:43:45Z"
+		},
+		{
+			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
+			"path": "golang.org/x/net/context/ctxhttp",
+			"revision": "ffcf1bedda3b04ebb15a168a59800a73d6dc0f4d",
+			"revisionTime": "2017-03-29T01:43:45Z"
+		},
+		{
+			"checksumSHA1": "vqc3a+oTUGX8PmD0TS+qQ7gmN8I=",
+			"path": "golang.org/x/net/html",
+			"revision": "ffcf1bedda3b04ebb15a168a59800a73d6dc0f4d",
+			"revisionTime": "2017-03-29T01:43:45Z"
+		},
+		{
+			"checksumSHA1": "z79z5msRzgU48FCZxSuxfU8b4rs=",
+			"path": "golang.org/x/net/html/atom",
+			"revision": "ffcf1bedda3b04ebb15a168a59800a73d6dc0f4d",
+			"revisionTime": "2017-03-29T01:43:45Z"
+		},
+		{
+			"checksumSHA1": "GvrtqfUw0+pPZ1ODQB+X1DqCQmM=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "8b4580aae2a0dd0c231a45d3ccb8434ff533b840",
+			"revisionTime": "2017-11-30T16:26:51Z"
+		},
+		{
+			"checksumSHA1": "riTVymIu2BFphV6UlA73Fn9tmmU=",
+			"path": "golang.org/x/sys/windows",
+			"revision": "8b4580aae2a0dd0c231a45d3ccb8434ff533b840",
+			"revisionTime": "2017-11-30T16:26:51Z"
+		},
+		{
+			"checksumSHA1": "XeOje6FklwIZfFMTgE583al/ZDo=",
+			"path": "gopkg.in/check.v1",
+			"revision": "64131543e7896d5bcc6bd5a76287eb75ea96c673",
+			"revisionTime": "2014-10-24T13:38:53Z"
+		},
+		{
+			"checksumSHA1": "nkSUCucyJWGp2kBsYMzQ+UcyftY=",
+			"path": "gopkg.in/errgo.v1",
+			"revision": "442357a80af5c6bf9b6d51ae791a39c3421004f3",
+			"revisionTime": "2016-12-22T12:58:16Z"
+		},
+		{
+			"checksumSHA1": "mWrTCVjXPLevlqKUqpzSoEM3tu8=",
+			"path": "gopkg.in/macaroon.v1",
+			"revision": "ab3940c6c16510a850e1c2dd628b919f0f3f1464",
+			"revisionTime": "2015-01-21T11:42:31Z"
+		},
+		{
+			"checksumSHA1": "lBMMakT63h9ywP4d5wlkhOYMCAs=",
+			"path": "gopkg.in/retry.v1",
+			"revision": "c09f6b86ba4d5d2cf5bdf0665364aec9fd4815db",
+			"revisionTime": "2016-10-25T18:07:18Z"
+		},
+		{
+			"checksumSHA1": "t95/FNK2nGCx3e6IARbO7OrcCuY=",
+			"path": "gopkg.in/tomb.v2",
+			"revision": "d5d1b5820637886def9eef33e03a27a9f166942c",
+			"revisionTime": "2016-12-08T15:16:19Z"
+		},
+		{
+			"checksumSHA1": "TXfll3dCoaPKSntwHO0yR8eZ4JY=",
+			"path": "gopkg.in/yaml.v2",
+			"revision": "49c95bdc21843256fb6c4e0d370a05f24a0bf213",
+			"revisionTime": "2015-02-24T22:57:58Z"
+		}
+	],
+	"rootPath": "github.com/CanonicalLtd/serial-vault"
+}


### PR DESCRIPTION
Updated run-checks with more checks and skipping vendor or not relevant folders
Fix code as run-checks demands
Update .md files lists to fit mdlint tests
Tested deb package successfully built in nightly ppa.
  - deb build tests by using `go tests` but cannot execute run-checks as it uses tools that should be downloaded in build time, what is not possible within ppa. Run-checks however are executed in github phase, so there's any trouble on skip them when building.

Note: Commented out shellcheck in run-checks script because there are a lot of warnings that has large correction. Please do this in another PR.

