### PR TITLE
Add a health check API to serial-vault

### DIFF
--- a/datastore/database.go
+++ b/datastore/database.go
@@ -114,6 +114,8 @@ type Datastore interface {
 	UpdateAllowedSubstore(store Substore, authorization User) error
 	DeleteAllowedSubstore(storeID int, authorization User) (string, error)
 	GetSubstore(fromModelID int, serialNumber string) (Substore, error)
+
+	HealthCheck() error
 }
 
 // DB local database interface with our custom methods.

--- a/datastore/mock_database.go
+++ b/datastore/mock_database.go
@@ -660,6 +660,11 @@ func (mdb *MockDB) GetSubstore(fromModelID int, serialNumber string) (Substore, 
 	return Substore{ID: 1, AccountID: 1, FromModelID: 1, FromModel: fromModel, Store: "mybrand", SerialNumber: "abc1234", ModelName: "alder-mybrand"}, nil
 }
 
+// HealthCheck mock for a healthy datastore
+func (mdb *MockDB) HealthCheck() error {
+	return nil
+}
+
 // -----------------------------------------------------------------------------
 
 // ErrorMockDB holds the unsuccessful mocks for the database
@@ -1056,4 +1061,9 @@ func (mdb *ErrorMockDB) DeleteAllowedSubstore(storeID int, authorization User) (
 // GetSubstore mock to get a substore record
 func (mdb *ErrorMockDB) GetSubstore(fromModelID int, serialNumber string) (Substore, error) {
 	return Substore{}, errors.New("Cannot get the sub-store model")
+}
+
+// HealthCheck mock to simulate failed HealthCheck
+func (mdb *ErrorMockDB) HealthCheck() error {
+	return errors.New("Health check failed")
 }

--- a/datastore/substoremanager.go
+++ b/datastore/substoremanager.go
@@ -152,6 +152,11 @@ func (db *DB) GetSubstore(fromModelID int, serialNumber string) (Substore, error
 	return store, nil
 }
 
+// HealthCheck returns an error if there is a problem talking to the underlying Datastore
+func (db *DB) HealthCheck() error {
+	return db.Ping()
+}
+
 // ListSubstores returns a list of sub-stores
 func (db *DB) listSubstores(accountID int) ([]Substore, error) {
 	rows, err := db.Query(listSubstoreSQL, accountID)

--- a/datastore/substoremanager.go
+++ b/datastore/substoremanager.go
@@ -154,7 +154,8 @@ func (db *DB) GetSubstore(fromModelID int, serialNumber string) (Substore, error
 
 // HealthCheck returns an error if there is a problem talking to the underlying Datastore
 func (db *DB) HealthCheck() error {
-	return db.Ping()
+	_, err := db.Exec("select 1;")
+	return err
 }
 
 // ListSubstores returns a list of sub-stores

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -94,8 +94,10 @@ func HealthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	err := datastore.Environ.DB.HealthCheck()
 	var database string
+
 	if err != nil {
 		database = err.Error()
+		w.WriteHeader(http.StatusBadRequest)
 	} else {
 		database = "healthy"
 	}

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -89,8 +89,8 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// HealthHander is the API method to return if the app is up and db.Ping() doesn't return an error
-func HealthHander(w http.ResponseWriter, r *http.Request) {
+// HealthHandler is the API method to return if the app is up and db.Ping() doesn't return an error
+func HealthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	err := datastore.Environ.DB.HealthCheck()
 	var database string

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -41,6 +41,11 @@ type VersionResponse struct {
 	Version string `json:"version"`
 }
 
+// HealthResponse is the JSON response from the health check method
+type HealthResponse struct {
+	Database string `json:"database"`
+}
+
 // RequestIDResponse is the JSON response from the API Version method
 type RequestIDResponse struct {
 	Success      bool   `json:"success"`
@@ -81,6 +86,23 @@ func VersionHandler(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		message := fmt.Sprintf("Error encoding the version response: %v", err)
 		logMessage("VERSION", "get-version", message)
+	}
+}
+
+// HealthHander is the API method to return if the app is up and db.Ping() doesn't return an error
+func HealthHander(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	err := datastore.Environ.DB.HealthCheck()
+	var database string
+	if err != nil {
+		database = err.Error()
+	} else {
+		database = "healthy"
+	}
+	response := HealthResponse{Database: database}
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		message := fmt.Sprintf("Error ecoding the health response: %v", err)
+		logMessage("HEALTH", "health", message)
 	}
 }
 

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -649,7 +649,7 @@ func TestHealthHandlerHealthy(t *testing.T) {
 	datastore.Environ = &datastore.Env{DB: &datastore.MockDB{}, Config: config}
 	response, _ := sendRequestHealth(t, "GET", "/v1/health", nil)
 
-	if response.Code != 200 {
+	if response.Code != http.StatusOK {
 		t.Errorf("Response to healthy data store should be 200 but was %v", response.Code)
 	}
 	result := HealthResponse{}
@@ -669,15 +669,16 @@ func TestHealthHandlerUnhealthy(t *testing.T) {
 	datastore.Environ = &datastore.Env{DB: &datastore.ErrorMockDB{}, Config: config}
 	response, _ := sendRequestHealth(t, "GET", "/v1/health", nil)
 
-	if response.Code != 500 {
-		t.Errorf("Response to healthy data store should be 500 but was %v", response.Code)
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("Response to healthy data store should be 400 but was %v", response.Code)
 	}
+
 	result := HealthResponse{}
 	err := json.NewDecoder(response.Body).Decode(&result)
 	if err != nil {
 		t.Errorf("Error decoding the health response: %v", err)
 	}
-	if result.Database != "healthy" {
+	if result.Database == "healthy" {
 		t.Errorf("Health endpoint should not have returned healthy, got %s", result.Database)
 	}
 

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -643,6 +643,45 @@ func TestVersionHandler(t *testing.T) {
 
 }
 
+func TestHealthHandlerHealthy(t *testing.T) {
+
+	config := config.Settings{KeyStoreType: "filesystem", KeyStorePath: "../keystore", JwtSecret: "SomeTestSecretValue"}
+	datastore.Environ = &datastore.Env{DB: &datastore.MockDB{}, Config: config}
+	response, _ := sendRequestHealth(t, "GET", "/v1/health", nil)
+
+	if response.Code != 200 {
+		t.Errorf("Response to healthy data store should be 200 but was %v", response.Code)
+	}
+	result := HealthResponse{}
+	err := json.NewDecoder(response.Body).Decode(&result)
+	if err != nil {
+		t.Errorf("Error decoding the health response: %v", err)
+	}
+	if result.Database != "healthy" {
+		t.Errorf("Health endpoint should have returned healthy, instead got %s", result.Database)
+	}
+
+}
+
+func TestHealthHandlerUnhealthy(t *testing.T) {
+
+	config := config.Settings{KeyStoreType: "filesystem", KeyStorePath: "../keystore", JwtSecret: "SomeTestSecretValue"}
+	datastore.Environ = &datastore.Env{DB: &datastore.ErrorMockDB{}, Config: config}
+	response, _ := sendRequestHealth(t, "GET", "/v1/health", nil)
+
+	if response.Code != 500 {
+		t.Errorf("Response to healthy data store should be 500 but was %v", response.Code)
+	}
+	result := HealthResponse{}
+	err := json.NewDecoder(response.Body).Decode(&result)
+	if err != nil {
+		t.Errorf("Error decoding the health response: %v", err)
+	}
+	if result.Database != "healthy" {
+		t.Errorf("Health endpoint should not have returned healthy, got %s", result.Database)
+	}
+
+}
 func TestTokenHandler(t *testing.T) {
 
 	config := config.Settings{EnableUserAuth: true, JwtSecret: "SomeTestSecretValue"}
@@ -669,6 +708,14 @@ func sendRequestVersion(t *testing.T, method, url string, data io.Reader) (Versi
 	}
 
 	return result, err
+}
+
+func sendRequestHealth(t *testing.T, method, url string, data io.Reader) (httptest.ResponseRecorder, error) {
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest(method, url, data)
+	SigningRouter().ServeHTTP(w, r)
+
+	return *w, err
 }
 
 func createJWT(r *http.Request, t *testing.T) {

--- a/service/router.go
+++ b/service/router.go
@@ -39,7 +39,7 @@ func SigningRouter() *mux.Router {
 
 	// API routes
 	router.Handle("/v1/version", Middleware(http.HandlerFunc(VersionHandler))).Methods("GET")
-	router.Handle("/v1/health", Middleware(http.HandlerFunc(HealthHander))).Methods("GET")
+	router.Handle("/v1/health", Middleware(http.HandlerFunc(HealthHandler))).Methods("GET")
 	router.Handle("/v1/serial", Middleware(ErrorHandler(SignHandler))).Methods("POST")
 	router.Handle("/v1/request-id", Middleware(ErrorHandler(RequestIDHandler))).Methods("POST")
 	router.Handle("/v1/model", Middleware(ErrorHandler(ModelAssertionHandler))).Methods("POST")

--- a/service/router.go
+++ b/service/router.go
@@ -39,6 +39,7 @@ func SigningRouter() *mux.Router {
 
 	// API routes
 	router.Handle("/v1/version", Middleware(http.HandlerFunc(VersionHandler))).Methods("GET")
+	router.Handle("/v1/health", Middleware(http.HandlerFunc(HealthHander))).Methods("GET")
 	router.Handle("/v1/serial", Middleware(ErrorHandler(SignHandler))).Methods("POST")
 	router.Handle("/v1/request-id", Middleware(ErrorHandler(RequestIDHandler))).Methods("POST")
 	router.Handle("/v1/model", Middleware(ErrorHandler(ModelAssertionHandler))).Methods("POST")


### PR DESCRIPTION
`/v1/health` checks to ensure that the database is accessible using the
db.Ping() function.

