### PR TITLE
Form to cache test logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ snap/.snapcraft
 .tests-extras
 vendor/*/
 __pycache__/
+files/

--- a/keystore/example_report.xml
+++ b/keystore/example_report.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test_report>
+    <uuts>
+        <uut>
+            <summary>
+                <part_number>860-00014</part_number>
+                <serial_number>e4bf7ceb-f7af-442e-b734-5432ef3306b5</serial_number>
+                <operation>Validation Test</operation>
+                <started_at>2018-04-09T17:44:16+02:00</started_at>
+                <ended_at>2018-04-09T17:44:16+02:00</ended_at>
+                <status>Failed</status>
+            </summary>
+            <tests>
+                <test>
+                    <name>factory_cpu/iMX6ULL</name>
+                    <status>failed</status>
+                </test>
+                <test>
+                    <name>factory_ethernet/card-detect</name>
+                    <status>failed</status>
+                </test>
+                <test>
+                    <name>factory_hdd/drive-count</name>
+                    <status>failed</status>
+                </test>
+                <test>
+                    <name>factory_RAM/size</name>
+                    <status>passed</status>
+                </test>
+                <test>
+                    <name>factory_RTC</name>
+                    <status>failed</status>
+                </test>
+                <test>
+                    <name>factory_usb/usb2-root-hub-present</name>
+                    <status>passed</status>
+                </test>
+            </tests>
+</uut>
+</uuts>
+</test_report>

--- a/service/router.go
+++ b/service/router.go
@@ -36,6 +36,7 @@ import (
 	"github.com/CanonicalLtd/serial-vault/service/signinglog"
 	"github.com/CanonicalLtd/serial-vault/service/store"
 	"github.com/CanonicalLtd/serial-vault/service/substore"
+	"github.com/CanonicalLtd/serial-vault/service/testlog"
 	"github.com/CanonicalLtd/serial-vault/service/user"
 	"github.com/CanonicalLtd/serial-vault/usso"
 	"github.com/gorilla/mux"
@@ -55,6 +56,12 @@ func SigningRouter() *mux.Router {
 	router.Handle("/v1/pivot", Middleware(ErrorHandler(pivot.Model))).Methods("POST")
 	router.Handle("/v1/pivotmodel", Middleware(ErrorHandler(pivot.ModelAssertion))).Methods("POST")
 	router.Handle("/v1/pivotserial", Middleware(ErrorHandler(pivot.SerialAssertion))).Methods("POST")
+
+	// Test log upload routes (only in the factory)
+	if datastore.Environ.Config.Driver == "sqlite3" {
+		router.Handle("/testlog", Middleware(http.HandlerFunc(testlog.Index))).Methods("GET")
+		router.Handle("/testlog", Middleware(http.HandlerFunc(testlog.Submit))).Methods("POST")
+	}
 
 	return router
 }

--- a/service/testlog/handlers_testlog.go
+++ b/service/testlog/handlers_testlog.go
@@ -114,6 +114,7 @@ func saveFile(w http.ResponseWriter, file multipart.File, handle *multipart.File
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		if err = os.Mkdir(path, 0755); err != nil {
 			formatUploadResponse(w, http.StatusBadRequest, err.Error())
+			return
 		}
 	}
 

--- a/service/testlog/handlers_testlog.go
+++ b/service/testlog/handlers_testlog.go
@@ -1,0 +1,123 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ * License granted by Canonical Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testlog
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"text/template"
+	"time"
+
+	"github.com/CanonicalLtd/serial-vault/service/response"
+)
+
+const tpl = `
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Test Log Upload</title>
+		<style>
+		body {font-family: Ubuntu,Roboto,sans-serif}
+		h1   {margin-top: 0; padding: 10px 10px; background-color: #E95420; color: #fff; font-weight: normal}
+		div { margin: 40px}
+		fieldset { padding: 20px}
+		</style>
+    </head>
+    <body>
+		<h1>Serial Vault</h1>
+		<div>
+			<h2>Test Log Upload</h2>
+			<form action="/testlog" method="POST" enctype="multipart/form-data">
+				<fieldset>
+				<label for="logfile">Filename:</label><br />
+				<input type="file" name="logfile" accept="text/xml">
+				<input type="Submit">
+				</fieldset>
+			</form>
+		</div>
+	</body>
+</html>
+`
+const paramsEnvVar = "SNAP_DATA"
+
+// Index is the form of the test log upload web application
+func Index(w http.ResponseWriter, r *http.Request) {
+	t, err := template.New("testlog").Parse(tpl)
+	if err != nil {
+		log.Printf("Error loading the application template: %v\n", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	err = t.Execute(w, nil)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// Submit is the POST request for caching a test log
+func Submit(w http.ResponseWriter, r *http.Request) {
+	file, handle, err := r.FormFile("logfile")
+	if err != nil {
+		formatUploadResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	defer file.Close()
+
+	saveFile(w, file, handle)
+}
+
+func formatUploadResponse(w http.ResponseWriter, code int, message string) {
+	w.Header().Set("Content-Type", response.JSONHeader)
+	w.WriteHeader(code)
+	fmt.Fprint(w, message)
+}
+
+func saveFile(w http.ResponseWriter, file multipart.File, handle *multipart.FileHeader) {
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		formatUploadResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Set up the path for the file
+	path := os.Getenv(paramsEnvVar)
+	if len(path) == 0 {
+		path = "."
+	}
+	path = path + "/files"
+	_ = os.Mkdir(path, 0755)
+
+	// Generate a filename
+	filename := fmt.Sprintf("%s/%d%s", path, time.Now().Unix(), handle.Filename)
+
+	// Save the file
+	err = ioutil.WriteFile(filename, data, 0666)
+	if err != nil {
+		fmt.Fprintf(w, "%v", err)
+		return
+	}
+	formatUploadResponse(w, http.StatusCreated, "File uploaded successfully")
+}

--- a/service/testlog/handlers_testlog_test.go
+++ b/service/testlog/handlers_testlog_test.go
@@ -1,0 +1,118 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ * License granted by Canonical Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testlog_test
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/CanonicalLtd/serial-vault/config"
+	"github.com/CanonicalLtd/serial-vault/datastore"
+	"github.com/CanonicalLtd/serial-vault/service"
+	"github.com/CanonicalLtd/serial-vault/service/response"
+	check "gopkg.in/check.v1"
+)
+
+func TestLogSuite(t *testing.T) { check.TestingT(t) }
+
+type LogSuite struct{}
+
+type SuiteTest struct {
+	Method   string
+	URL      string
+	Data     []byte
+	Path     string
+	Filename string
+	Code     int
+	Type     string
+	Message  string
+}
+
+var _ = check.Suite(&LogSuite{})
+
+func (s *LogSuite) SetUpTest(c *check.C) {
+	// Mock the database
+	config := config.Settings{Driver: "sqlite3", KeyStoreType: "filesystem", KeyStorePath: "../keystore", JwtSecret: "SomeTestSecretValue"}
+	datastore.Environ = &datastore.Env{DB: &datastore.MockDB{}, Config: config}
+	datastore.OpenKeyStore(config)
+}
+
+func sendSigningRequest(method, url string, data io.Reader, path, filename string, c *check.C) *httptest.ResponseRecorder {
+	var r *http.Request
+	w := httptest.NewRecorder()
+
+	if len(path) != 0 {
+		ctype, body, err := createFile(path, filename, c)
+		c.Assert(err, check.IsNil)
+		r, _ = http.NewRequest(method, url, body)
+		r.Header.Add("Content-Type", ctype)
+	} else {
+		r, _ = http.NewRequest(method, url, data)
+	}
+
+	service.SigningRouter().ServeHTTP(w, r)
+
+	return w
+}
+
+func (s *LogSuite) TestSubstoresHandler(c *check.C) {
+	tests := []SuiteTest{
+		{"GET", "/testlog", nil, "", "", 200, "text/html; charset=utf-8", ""},
+		{"POST", "/testlog", nil, "", "", 400, response.JSONHeader, ""},
+		{"POST", "/testlog", []byte(""), "", "", 400, response.JSONHeader, ""},
+		{"POST", "/testlog", []byte(""), "../../keystore/example_report.xml", "logfile", 201, response.JSONHeader, ""},
+	}
+
+	for _, t := range tests {
+		w := sendSigningRequest(t.Method, t.URL, bytes.NewReader(t.Data), t.Path, t.Filename, c)
+		c.Assert(w.Code, check.Equals, t.Code)
+		c.Assert(w.Header().Get("Content-Type"), check.Equals, t.Type)
+	}
+}
+
+func createFile(path, filename string, c *check.C) (string, *bytes.Buffer, error) {
+	file, err := os.Open(path)
+	c.Assert(err, check.IsNil)
+	defer file.Close()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile(filename, filepath.Base(path))
+	if err != nil {
+		return "", nil, err
+	}
+
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if err = writer.Close(); err != nil {
+		return "", nil, err
+	}
+	return writer.FormDataContentType(), body, nil
+}


### PR DESCRIPTION
Add a form to the factory signing service that allows test logs to be cached to disk