### PR TITLE
Sync API for test logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ If you have a Go development environment set up, Go get it:
 - Create the database tables:
   ```bash
   $ cd serial-vault
+  $ ./get-deps.sh
   $ go run cmd/serial-vault-admin/main.go database --config=/path/to/settings.yaml
   ```
 

--- a/datastore/database.go
+++ b/datastore/database.go
@@ -1,7 +1,8 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
+ * License granted by Canonical Limited
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -112,6 +113,10 @@ type Datastore interface {
 	UpdateAllowedSubstore(store Substore, authorization User) error
 	DeleteAllowedSubstore(storeID int, authorization User) (string, error)
 	GetSubstore(fromModelID int, serialNumber string) (Substore, error)
+
+	CreateTestLogTable() error
+	CreateTestLog(testLog TestLog) error
+	ListAllowedTestLog(authorization User) ([]TestLog, error)
 
 	HealthCheck() error
 

--- a/datastore/database.go
+++ b/datastore/database.go
@@ -39,6 +39,7 @@ type Datastore interface {
 	CreateModelTable() error
 	AlterModelTable() error
 	CheckAPIKey(apiKey string) bool
+	CheckModelExists(brandID, name string) bool
 
 	CreateModelAssertTable() error
 	CreateModelAssert(m ModelAssertion) (int, error)

--- a/datastore/database.go
+++ b/datastore/database.go
@@ -176,3 +176,11 @@ func (db *DB) transaction(txFunc func(*sql.Tx) error) error {
 	err = txFunc(tx)
 	return err
 }
+
+// InFactory checks if we are running in the factory (with a sqlite database)
+func InFactory() bool {
+	if Environ.Config.Driver == "sqlite3" {
+		return true
+	}
+	return false
+}

--- a/datastore/keypairmanager.go
+++ b/datastore/keypairmanager.go
@@ -24,7 +24,6 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"strings"
 )
 
 const createKeypairTableSQL = `
@@ -196,7 +195,7 @@ func (db *DB) GetKeypairByName(authorityID, keyName string) (Keypair, error) {
 // PutKeypair stores a keypair in the database
 func (db *DB) PutKeypair(keypair Keypair) (string, error) {
 	// Validate the data
-	if strings.TrimSpace(keypair.AuthorityID) == "" || strings.TrimSpace(keypair.KeyID) == "" {
+	if validateStringsNotEmpty(keypair.AuthorityID, keypair.KeyID) {
 		return "error-validate-keypair", errors.New("The Authority ID and the Key ID must be entered")
 	}
 
@@ -212,7 +211,7 @@ func (db *DB) PutKeypair(keypair Keypair) (string, error) {
 // SyncKeypair stores a keypair in the database
 func (db *DB) SyncKeypair(keypair SyncKeypair) error {
 	// Validate the data
-	if strings.TrimSpace(keypair.AuthorityID) == "" || strings.TrimSpace(keypair.KeyID) == "" {
+	if validateStringsNotEmpty(keypair.AuthorityID, keypair.KeyID) {
 		return errors.New("The Authority ID and the Key ID must be entered")
 	}
 

--- a/datastore/mock_database.go
+++ b/datastore/mock_database.go
@@ -164,6 +164,15 @@ func (mdb *MockDB) FindModel(brandID, modelName, apiKey string) (Model, error) {
 	return model, nil
 }
 
+// CheckModelExists mocks the database response for finding a model
+func (mdb *MockDB) CheckModelExists(brandID, modelName string) bool {
+	model := Model{ID: 1, BrandID: "system", Name: "alder", KeypairID: 1, AuthorityID: "system", KeyID: "UytTqTvREVhx0tSfYC6KkFHmLWllIIZbQ3NsEG7OARrWuaXSRJyey0vjIQkTEvMO", KeyActive: true, SealedKey: ""}
+	if model.BrandID != brandID || model.Name != modelName || modelName == "invalid" {
+		return false
+	}
+	return true
+}
+
 // CheckAPIKey mocks the database response to check the API key
 func (mdb *MockDB) CheckAPIKey(apiKey string) bool {
 	if apiKey == "InvalidAPIKey" {
@@ -741,6 +750,15 @@ func (mdb *MockDB) CreateTestLog(testLog TestLog) error {
 	return nil
 }
 
+// ListAllowedTestLog database mock
+func (mdb *MockDB) ListAllowedTestLog(authorization User) ([]TestLog, error) {
+	logs := []TestLog{
+		{ID: 1, Brand: "system", Model: "alder", Filename: "test1.xml"},
+		{ID: 2, Brand: "system", Model: "alder", Filename: "test2.xml"},
+	}
+	return logs, nil
+}
+
 // HealthCheck mock for a healthy datastore
 func (mdb *MockDB) HealthCheck() error {
 	return nil
@@ -855,6 +873,11 @@ func (mdb *ErrorMockDB) ListAllowedModels(authorization User) ([]Model, error) {
 // FindModel mocks the database response for finding a model, returning an invalid signing-key
 func (mdb *ErrorMockDB) FindModel(brandID, modelName, apiKey string) (Model, error) {
 	return Model{}, errors.New("Error finding the model")
+}
+
+// CheckModelExists mocks the database response for finding a model
+func (mdb *ErrorMockDB) CheckModelExists(brandID, modelName string) bool {
+	return false
 }
 
 // CheckAPIKey mocks the database response to check the API key
@@ -1188,6 +1211,11 @@ func (mdb *ErrorMockDB) GetSubstore(fromModelID int, serialNumber string) (Subst
 // CreateTestLog mock to create a test log
 func (mdb *ErrorMockDB) CreateTestLog(testLog TestLog) error {
 	return errors.New("MOCK Cannot create the test log")
+}
+
+// ListAllowedTestLog database mock
+func (mdb *ErrorMockDB) ListAllowedTestLog(authorization User) ([]TestLog, error) {
+	return nil, errors.New("MOCK Cannot fetch the test logs")
 }
 
 // HealthCheck mock to simulate failed HealthCheck

--- a/datastore/mock_database.go
+++ b/datastore/mock_database.go
@@ -327,6 +327,11 @@ func (mdb *MockDB) CreateSigningLogTable() error {
 	return nil
 }
 
+// CreateTestLogTable error mock for the database
+func (mdb *MockDB) CreateTestLogTable() error {
+	return nil
+}
+
 // CheckForDuplicate database mock
 func (mdb *MockDB) CheckForDuplicate(signLog *SigningLog) (bool, int, error) {
 	switch signLog.SerialNumber {
@@ -731,6 +736,11 @@ func (mdb *MockDB) GetSubstore(fromModelID int, serialNumber string) (Substore, 
 	return Substore{ID: 1, AccountID: 1, FromModelID: 1, FromModel: fromModel, Store: "mybrand", SerialNumber: "abc1234", ModelName: "alder-mybrand"}, nil
 }
 
+// CreateTestLog mock to create a test log
+func (mdb *MockDB) CreateTestLog(testLog TestLog) error {
+	return nil
+}
+
 // HealthCheck mock for a healthy datastore
 func (mdb *MockDB) HealthCheck() error {
 	return nil
@@ -951,6 +961,11 @@ func (mdb *ErrorMockDB) CreateSigningLogTable() error {
 	return nil
 }
 
+// CreateTestLogTable error mock for the database
+func (mdb *ErrorMockDB) CreateTestLogTable() error {
+	return nil
+}
+
 // ListAllowedSigningLog error mock for the database
 func (mdb *ErrorMockDB) ListAllowedSigningLog(authorization User) ([]SigningLog, error) {
 	var signingLog []SigningLog
@@ -1168,6 +1183,11 @@ func (mdb *ErrorMockDB) DeleteAllowedSubstore(storeID int, authorization User) (
 // GetSubstore mock to get a substore record
 func (mdb *ErrorMockDB) GetSubstore(fromModelID int, serialNumber string) (Substore, error) {
 	return Substore{}, errors.New("Cannot get the sub-store model")
+}
+
+// CreateTestLog mock to create a test log
+func (mdb *ErrorMockDB) CreateTestLog(testLog TestLog) error {
+	return errors.New("MOCK Cannot create the test log")
 }
 
 // HealthCheck mock to simulate failed HealthCheck

--- a/datastore/modeladapter.go
+++ b/datastore/modeladapter.go
@@ -129,7 +129,7 @@ func (db *DB) CreateAllowedModel(model Model, authorization User) (Model, string
 	model.APIKey = apiKey
 
 	// Check that the model does not exist
-	if found := db.checkModelExists(model.BrandID, model.Name); found {
+	if found := db.CheckModelExists(model.BrandID, model.Name); found {
 		return model, "error-model-exists", errors.New("A device with the same Brand and Model already exists")
 	}
 

--- a/datastore/modelmanager.go
+++ b/datastore/modelmanager.go
@@ -442,8 +442,8 @@ func (db *DB) CheckAPIKey(apiKey string) bool {
 	return db.checkBoolQuery(row)
 }
 
-// CheckAPIKey validates that there is a model for the supplied API key
-func (db *DB) checkModelExists(brandID, name string) bool {
+// CheckModelExists validates that there is a model for the brand and name
+func (db *DB) CheckModelExists(brandID, name string) bool {
 	row := db.QueryRow(checkModelExistsSQL, brandID, name)
 	return db.checkBoolQuery(row)
 }

--- a/datastore/noncemanager.go
+++ b/datastore/noncemanager.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -89,7 +89,7 @@ func (db *DB) CreateDeviceNonce() (DeviceNonce, error) {
 	}
 
 	// Create the nonce in the database
-	if Environ.Config.Driver == "sqlite3" {
+	if InFactory() {
 		// Need to generate our own ID
 		var nextID int
 		err = db.QueryRow(maxIDDeviceNonceSQLite).Scan(&nextID)

--- a/datastore/settingsmanager.go
+++ b/datastore/settingsmanager.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -22,7 +22,6 @@ package datastore
 import (
 	"errors"
 	"log"
-	"strings"
 )
 
 // Understood settings codes
@@ -80,11 +79,11 @@ func (db *DB) CreateSettingsTable() error {
 func (db *DB) PutSetting(setting Setting) error {
 	var err error
 	// Validate the data
-	if strings.TrimSpace(setting.Code) == "" {
+	if err := validateNotEmpty("code", setting.Code); err != nil {
 		return errors.New("The code must be entered to store a Setting")
 	}
 
-	if Environ.Config.Driver == "sqlite3" {
+	if InFactory() {
 		// We only add new settings for the factory, we don't ever update a setting
 		// Need to generate our own ID
 		var nextID int

--- a/datastore/signinglogadapter.go
+++ b/datastore/signinglogadapter.go
@@ -26,6 +26,8 @@ func (db *DB) ListAllowedSigningLog(authorization User) ([]SigningLog, error) {
 		fallthrough
 	case Superuser:
 		return db.listAllSigningLog()
+	case SyncUser:
+		fallthrough
 	case Admin:
 		return db.listSigningLogFilteredByUser(authorization.Username)
 	default:

--- a/datastore/signinglogmanager.go
+++ b/datastore/signinglogmanager.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2016-2017 Canonical Ltd
+ * Copyright (C) 2016-2018 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -23,7 +23,6 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"strings"
 	"time"
 )
 
@@ -177,12 +176,12 @@ func (db *DB) CheckForMatching(signLog SigningLog) (bool, error) {
 func (db *DB) CreateSigningLog(signLog SigningLog) error {
 	var err error
 	// Validate the data
-	if strings.TrimSpace(signLog.Make) == "" || strings.TrimSpace(signLog.Model) == "" || strings.TrimSpace(signLog.SerialNumber) == "" || strings.TrimSpace(signLog.Fingerprint) == "" {
+	if validateStringsNotEmpty(signLog.Make, signLog.Model, signLog.SerialNumber, signLog.Fingerprint) {
 		return errors.New("The Make, Model, Serial Number and device-key Fingerprint must be supplied")
 	}
 
 	// Create the signing log in the database
-	if Environ.Config.Driver == "sqlite3" {
+	if InFactory() {
 		// Need to generate our own ID
 		var nextID int
 		err = db.QueryRow(maxIDSigningLogSQLite).Scan(&nextID)
@@ -209,7 +208,7 @@ func (db *DB) CreateSigningLog(signLog SigningLog) error {
 func (db *DB) CreateSigningLogSync(signLog SigningLog) error {
 	var err error
 	// Validate the data
-	if strings.TrimSpace(signLog.Make) == "" || strings.TrimSpace(signLog.Model) == "" || strings.TrimSpace(signLog.SerialNumber) == "" || strings.TrimSpace(signLog.Fingerprint) == "" {
+	if validateStringsNotEmpty(signLog.Make, signLog.Model, signLog.SerialNumber, signLog.Fingerprint) {
 		return errors.New("The Make, Model, Serial Number and device-key Fingerprint must be supplied")
 	}
 

--- a/datastore/testlogadapter.go
+++ b/datastore/testlogadapter.go
@@ -1,0 +1,35 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ * License granted by Canonical Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package datastore
+
+// ListAllowedTestLog return test logs the user is authorized to see
+func (db *DB) ListAllowedTestLog(authorization User) ([]TestLog, error) {
+	switch authorization.Role {
+	case Invalid: // Authentication disabled
+		fallthrough
+	case Superuser:
+		return db.listAllTestLog()
+	case Admin:
+		return db.listTestLogFilteredByUser(authorization.Username)
+	default:
+		return []TestLog{}, nil
+	}
+}

--- a/datastore/testlogmanager.go
+++ b/datastore/testlogmanager.go
@@ -24,7 +24,6 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"strings"
 	"time"
 )
 
@@ -69,23 +68,19 @@ type TestLog struct {
 // CreateTestLogTable creates the database table for a test log
 func (db *DB) CreateTestLogTable() error {
 	_, err := db.Exec(createTestLogTableSQL)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // CreateTestLog keeps a record of a test log
 func (db *DB) CreateTestLog(testLog TestLog) error {
 	var err error
 	// Validate the data
-	if strings.TrimSpace(testLog.Brand) == "" || strings.TrimSpace(testLog.Model) == "" || strings.TrimSpace(testLog.Filename) == "" || strings.TrimSpace(testLog.Data) == "" {
+	if validateStringsNotEmpty(testLog.Brand, testLog.Model, testLog.Filename, testLog.Data) {
 		return errors.New("The brand, model, filename and file (base64-encoded) must be supplied")
 	}
 
 	// Create the signing log in the database
-	if Environ.Config.Driver == "sqlite3" {
+	if InFactory() {
 		// Need to generate our own ID
 		var nextID int
 		err = db.QueryRow(maxIDTestLogSQLite).Scan(&nextID)

--- a/datastore/testlogmanager.go
+++ b/datastore/testlogmanager.go
@@ -35,14 +35,13 @@ const createTestLogTableSQL = `
 		model            varchar(200) not null,
 		filename         varchar(200) not null,
 		data             text,
-		logged           int,
 		created          timestamp default current_timestamp,
 		synced           timestamp
 	)
 `
 
-const createTestLogSQLite = "INSERT INTO testlog (id,brand_id,model,filename,data,logged) VALUES ($1, $2, $3, $4, $5, $6)"
-const createTestLogSQL = "INSERT INTO testlog (brand_id,model,filename,data,logged) VALUES ($1, $2, $3, $4, $5)"
+const createTestLogSQLite = "INSERT INTO testlog (id,brand_id,model,filename,data) VALUES ($1, $2, $3, $4, $5)"
+const createTestLogSQL = "INSERT INTO testlog (brand_id,model,filename,data) VALUES ($1, $2, $3, $4)"
 
 const listTestLogSQL = "SELECT * FROM testlog WHERE not synced"
 const listTestLogForUserSQL = `
@@ -63,7 +62,6 @@ type TestLog struct {
 	Model    string    `json:"model"`
 	Filename string    `json:"filename"`
 	Data     string    `json:"data"`
-	Logged   int       `json:"logged"`
 	Created  time.Time `json:"created"`
 	Synced   time.Time `json:"synced"` // used to indicate it has been synced to an external system
 }
@@ -96,9 +94,9 @@ func (db *DB) CreateTestLog(testLog TestLog) error {
 			return err
 		}
 
-		_, err = db.Exec(createTestLogSQLite, nextID, testLog.Brand, testLog.Model, testLog.Filename, testLog.Data, testLog.Logged)
+		_, err = db.Exec(createTestLogSQLite, nextID, testLog.Brand, testLog.Model, testLog.Filename, testLog.Data)
 	} else {
-		_, err = db.Exec(createTestLogSQL, testLog.Brand, testLog.Model, testLog.Filename, testLog.Data, testLog.Logged)
+		_, err = db.Exec(createTestLogSQL, testLog.Brand, testLog.Model, testLog.Filename, testLog.Data)
 	}
 
 	// Create the log in the database
@@ -135,7 +133,7 @@ func (db *DB) listTestLogFilteredByUser(username string) ([]TestLog, error) {
 
 	for rows.Next() {
 		testLog := TestLog{}
-		err := rows.Scan(&testLog.ID, &testLog.Brand, &testLog.Model, &testLog.Filename, &testLog.Data, &testLog.Logged, &testLog.Created, &testLog.Synced)
+		err := rows.Scan(&testLog.ID, &testLog.Brand, &testLog.Model, &testLog.Filename, &testLog.Data, &testLog.Created, &testLog.Synced)
 		if err != nil {
 			return nil, err
 		}

--- a/datastore/testlogmanager.go
+++ b/datastore/testlogmanager.go
@@ -1,0 +1,146 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ * License granted by Canonical Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package datastore
+
+import (
+	"database/sql"
+	"errors"
+	"log"
+	"strings"
+	"time"
+)
+
+const createTestLogTableSQL = `
+	CREATE TABLE IF NOT EXISTS testlog (
+		id               serial primary key not null,
+		brand_id         varchar(200) not null,
+		model            varchar(200) not null,
+		filename         varchar(200) not null,
+		data             text,
+		logged           int,
+		created          timestamp default current_timestamp,
+		synced           timestamp
+	)
+`
+
+const createTestLogSQLite = "INSERT INTO testlog (id,brand_id,model,filename,data,logged) VALUES ($1, $2, $3, $4, $5, $6)"
+const createTestLogSQL = "INSERT INTO testlog (brand_id,model,filename,data,logged) VALUES ($1, $2, $3, $4, $5)"
+
+const listTestLogSQL = "SELECT * FROM testlog WHERE not synced"
+const listTestLogForUserSQL = `
+	SELECT t.* FROM testlog t
+	WHERE EXISTS(
+		SELECT * FROM account acc
+		INNER JOIN useraccountlink ua on ua.account_id=acc.id
+		INNER JOIN userinfo u on ua.user_id=u.id
+		WHERE acc.authority_id=t.brand_id and u.username=$1
+	)
+`
+const maxIDTestLogSQLite = "SELECT COUNT(*)+1 from testlog"
+
+// TestLog holds a test log sync-ed from the factory
+type TestLog struct {
+	ID       int       `json:"id"`
+	Brand    string    `json:"brand_id"`
+	Model    string    `json:"model"`
+	Filename string    `json:"filename"`
+	Data     string    `json:"data"`
+	Logged   int       `json:"logged"`
+	Created  time.Time `json:"created"`
+	Synced   time.Time `json:"synced"` // used to indicate it has been synced to an external system
+}
+
+// CreateTestLogTable creates the database table for a test log
+func (db *DB) CreateTestLogTable() error {
+	_, err := db.Exec(createTestLogTableSQL)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateTestLog keeps a record of a test log
+func (db *DB) CreateTestLog(testLog TestLog) error {
+	var err error
+	// Validate the data
+	if strings.TrimSpace(testLog.Brand) == "" || strings.TrimSpace(testLog.Model) == "" || strings.TrimSpace(testLog.Filename) == "" || strings.TrimSpace(testLog.Data) == "" {
+		return errors.New("The brand, model, filename and file (base64-encoded) must be supplied")
+	}
+
+	// Create the signing log in the database
+	if Environ.Config.Driver == "sqlite3" {
+		// Need to generate our own ID
+		var nextID int
+		err = db.QueryRow(maxIDTestLogSQLite).Scan(&nextID)
+		if err != nil {
+			log.Printf("Error retrieving next test log ID: %v\n", err)
+			return err
+		}
+
+		_, err = db.Exec(createTestLogSQLite, nextID, testLog.Brand, testLog.Model, testLog.Filename, testLog.Data, testLog.Logged)
+	} else {
+		_, err = db.Exec(createTestLogSQL, testLog.Brand, testLog.Model, testLog.Filename, testLog.Data, testLog.Logged)
+	}
+
+	// Create the log in the database
+	if err != nil {
+		log.Printf("Error creating the test log: %v\n", err)
+		return err
+	}
+
+	return nil
+}
+
+func (db *DB) listAllTestLog() ([]TestLog, error) {
+	return db.listTestLogFilteredByUser(anyUserFilter)
+}
+
+func (db *DB) listTestLogFilteredByUser(username string) ([]TestLog, error) {
+	testLogs := []TestLog{}
+
+	var (
+		rows *sql.Rows
+		err  error
+	)
+
+	if len(username) == 0 {
+		rows, err = db.Query(listTestLogSQL)
+	} else {
+		rows, err = db.Query(listTestLogForUserSQL, username)
+	}
+	if err != nil {
+		log.Printf("Error retrieving test logs: %v\n", err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		testLog := TestLog{}
+		err := rows.Scan(&testLog.ID, &testLog.Brand, &testLog.Model, &testLog.Filename, &testLog.Data, &testLog.Logged, &testLog.Created, &testLog.Synced)
+		if err != nil {
+			return nil, err
+		}
+		testLogs = append(testLogs, testLog)
+	}
+
+	return testLogs, nil
+}

--- a/datastore/validator.go
+++ b/datastore/validator.go
@@ -1,3 +1,23 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017-2018 Canonical Ltd
+ * License granted by Canonical Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package datastore
 
 import (
@@ -13,6 +33,15 @@ func validateNotEmpty(fieldName, fieldValue string) error {
 		return fmt.Errorf("%v must not be empty", normalize(fieldName))
 	}
 	return nil
+}
+
+func validateStringsNotEmpty(args ...string) bool {
+	for _, s := range args {
+		if len(strings.TrimSpace(s)) == 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func validateSyntax(fieldName, fieldValue string, regularExpression *regexp.Regexp) error {

--- a/manage/database.go
+++ b/manage/database.go
@@ -50,7 +50,7 @@ func execOne(method func() error, action, tableName string) {
 
 func exec(operations []operation) {
 	for _, op := range operations {
-		if op.skipSqlite && datastore.Environ.Config.Driver == "sqlite3" {
+		if op.skipSqlite && datastore.InFactory() {
 			continue
 		}
 		execOne(op.method, op.action, op.table)

--- a/manage/database.go
+++ b/manage/database.go
@@ -2,6 +2,7 @@
 
 /*
  * Copyright (C) 2017-2018 Canonical Ltd
+ * License granted by Canonical Limited
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -121,6 +122,9 @@ func UpdateDatabase() {
 
 		// Create the Sub-store table, if it does not exist
 		{datastore.Environ.DB.CreateSubstoreTable, create, "sub-store", false},
+
+		// Create the testlog table, if it does not exist
+		{datastore.Environ.DB.CreateTestLogTable, create, "testlog", false},
 	}
 
 	exec(operations)

--- a/service/router.go
+++ b/service/router.go
@@ -155,6 +155,7 @@ func AdminRouter() *mux.Router {
 	router.Handle("/api/keypairs/sync", Middleware(http.HandlerFunc(keypair.APISyncKeypairs))).Methods("POST")
 	router.Handle("/api/models", Middleware(http.HandlerFunc(model.APIList))).Methods("GET")
 	router.Handle("/api/signinglog", Middleware(http.HandlerFunc(signinglog.APISyncLog))).Methods("POST")
+	router.Handle("/api/testlog/{filename}", Middleware(http.HandlerFunc(testlog.APISyncLog))).Methods("POST")
 
 	return router
 }

--- a/service/router.go
+++ b/service/router.go
@@ -155,7 +155,7 @@ func AdminRouter() *mux.Router {
 	router.Handle("/api/keypairs/sync", Middleware(http.HandlerFunc(keypair.APISyncKeypairs))).Methods("POST")
 	router.Handle("/api/models", Middleware(http.HandlerFunc(model.APIList))).Methods("GET")
 	router.Handle("/api/signinglog", Middleware(http.HandlerFunc(signinglog.APISyncLog))).Methods("POST")
-	router.Handle("/api/testlog/{filename}", Middleware(http.HandlerFunc(testlog.APISyncLog))).Methods("POST")
+	router.Handle("/api/testlog", Middleware(http.HandlerFunc(testlog.APISyncLog))).Methods("POST")
 
 	return router
 }

--- a/service/router.go
+++ b/service/router.go
@@ -58,7 +58,7 @@ func SigningRouter() *mux.Router {
 	router.Handle("/v1/pivotserial", Middleware(ErrorHandler(pivot.SerialAssertion))).Methods("POST")
 
 	// Test log upload routes (only in the factory)
-	if datastore.Environ.Config.Driver == "sqlite3" {
+	if datastore.InFactory() {
 		router.Handle("/testlog", Middleware(http.HandlerFunc(testlog.Index))).Methods("GET")
 		router.Handle("/testlog", Middleware(http.HandlerFunc(testlog.Submit))).Methods("POST")
 	}

--- a/service/router.go
+++ b/service/router.go
@@ -155,6 +155,7 @@ func AdminRouter() *mux.Router {
 	router.Handle("/api/keypairs/sync", Middleware(http.HandlerFunc(keypair.APISyncKeypairs))).Methods("POST")
 	router.Handle("/api/models", Middleware(http.HandlerFunc(model.APIList))).Methods("GET")
 	router.Handle("/api/signinglog", Middleware(http.HandlerFunc(signinglog.APISyncLog))).Methods("POST")
+	router.Handle("/api/testlog", Middleware(http.HandlerFunc(testlog.APIListLog))).Methods("GET")
 	router.Handle("/api/testlog", Middleware(http.HandlerFunc(testlog.APISyncLog))).Methods("POST")
 
 	return router

--- a/service/testlog/actions.go
+++ b/service/testlog/actions.go
@@ -43,7 +43,7 @@ type ListResponse struct {
 func listHandler(w http.ResponseWriter, user datastore.User, apiCall bool) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 
-	err := auth.CheckUserPermissions(user, datastore.Admin, apiCall)
+	err := auth.CheckUserPermissions(user, datastore.SyncUser, apiCall)
 	if err != nil {
 		response.FormatStandardResponse(false, "error-auth", "", "", w)
 		return

--- a/service/testlog/actions.go
+++ b/service/testlog/actions.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ * License granted by Canonical Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testlog
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/CanonicalLtd/serial-vault/datastore"
+	"github.com/CanonicalLtd/serial-vault/service/auth"
+	"github.com/CanonicalLtd/serial-vault/service/response"
+)
+
+// ListResponse is the JSON response from the API Test Log method
+type ListResponse struct {
+	Success      bool                `json:"success"`
+	ErrorCode    string              `json:"error_code"`
+	ErrorSubcode string              `json:"error_subcode"`
+	ErrorMessage string              `json:"message"`
+	TestLog      []datastore.TestLog `json:"logs"`
+}
+
+// listHandler is the API method to fetch the log records from signing
+func listHandler(w http.ResponseWriter, user datastore.User, apiCall bool) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+
+	err := auth.CheckUserPermissions(user, datastore.Admin, apiCall)
+	if err != nil {
+		response.FormatStandardResponse(false, "error-auth", "", "", w)
+		return
+	}
+
+	logs, err := datastore.Environ.DB.ListAllowedTestLog(user)
+	if err != nil {
+		response.FormatStandardResponse(false, "error-fetch-signinglog", "", err.Error(), w)
+		return
+	}
+
+	// Return successful JSON response with the list of models
+	w.WriteHeader(http.StatusOK)
+	formatListResponse(true, "", "", "", logs, w)
+}
+
+func formatListResponse(success bool, errorCode, errorSubcode, message string, logs []datastore.TestLog, w http.ResponseWriter) error {
+	response := ListResponse{Success: success, ErrorCode: errorCode, ErrorSubcode: errorSubcode, ErrorMessage: message, TestLog: logs}
+
+	// Encode the response as JSON
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Println("Error forming the signing log response.")
+		return err
+	}
+	return nil
+}

--- a/service/testlog/actions_sync.go
+++ b/service/testlog/actions_sync.go
@@ -1,0 +1,84 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ * License granted by Canonical Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testlog
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/CanonicalLtd/serial-vault/datastore"
+	"github.com/CanonicalLtd/serial-vault/service/auth"
+	"github.com/CanonicalLtd/serial-vault/service/response"
+)
+
+func syncLogHandler(w http.ResponseWriter, user datastore.User, apiCall bool, testLog datastore.TestLog) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+
+	err := auth.CheckUserPermissions(user, datastore.SyncUser, apiCall)
+	if err != nil {
+		response.FormatStandardResponse(false, "error-auth", "", "", w)
+		return
+	}
+
+	if len(testLog.Data) == 0 {
+		response.FormatStandardResponse(false, "error-testlog-data", "", "No file data provided", w)
+		return
+	}
+
+	// Check we have something that's decodeable
+	_, err = base64.StdEncoding.DecodeString(testLog.Data)
+	if err != nil {
+		response.FormatStandardResponse(false, "error-testlog-data", "", err.Error(), w)
+		return
+	}
+
+	// Create the test log record (use the first account for the record)
+	err = datastore.Environ.DB.CreateTestLog(testLog)
+	if err != nil {
+		response.FormatStandardResponse(false, "error-testlog-create", "", err.Error(), w)
+		return
+	}
+
+	// Return successful JSON response
+	w.WriteHeader(http.StatusOK)
+	response.FormatStandardResponse(true, "", "", "", w)
+}
+
+// Filename is in the format <timestamp>_filename
+func parseFilename(filename string) (int, string) {
+	var f string
+	parts := strings.Split(filename, "_")
+	logged, err := strconv.Atoi(parts[0])
+	if err != nil {
+		// The filename is not in the expected format
+		f = filename
+		logged = 0
+	} else {
+		// Remove the timestamp from the filename
+		prefix := fmt.Sprintf("%d_", logged)
+		f = strings.Replace(filename, prefix, "", 1)
+	}
+
+	return logged, f
+}

--- a/service/testlog/actions_sync.go
+++ b/service/testlog/actions_sync.go
@@ -22,10 +22,7 @@ package testlog
 
 import (
 	"encoding/base64"
-	"fmt"
 	"net/http"
-	"strconv"
-	"strings"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/service/auth"
@@ -63,22 +60,4 @@ func syncLogHandler(w http.ResponseWriter, user datastore.User, apiCall bool, te
 	// Return successful JSON response
 	w.WriteHeader(http.StatusOK)
 	response.FormatStandardResponse(true, "", "", "", w)
-}
-
-// Filename is in the format <timestamp>_filename
-func parseFilename(filename string) (int, string) {
-	var f string
-	parts := strings.Split(filename, "_")
-	logged, err := strconv.Atoi(parts[0])
-	if err != nil {
-		// The filename is not in the expected format
-		f = filename
-		logged = 0
-	} else {
-		// Remove the timestamp from the filename
-		prefix := fmt.Sprintf("%d_", logged)
-		f = strings.Replace(filename, prefix, "", 1)
-	}
-
-	return logged, f
 }

--- a/service/testlog/handlers_adminapi.go
+++ b/service/testlog/handlers_adminapi.go
@@ -1,0 +1,70 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ * License granted by Canonical Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testlog
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/CanonicalLtd/serial-vault/datastore"
+	"github.com/CanonicalLtd/serial-vault/service/request"
+	"github.com/CanonicalLtd/serial-vault/service/response"
+)
+
+// APISyncLog is the API method to sync a factory test log to the cloud
+func APISyncLog(w http.ResponseWriter, r *http.Request) {
+	// Validate the user and API key
+	user, err := request.CheckUserAPI(r)
+	if err != nil {
+		response.FormatStandardResponse(false, "error-auth", "", err.Error(), w)
+		return
+	}
+
+	request := datastore.TestLog{}
+	err = json.NewDecoder(r.Body).Decode(&request)
+	switch {
+	// Check we have some data
+	case err == io.EOF:
+		response.FormatStandardResponse(false, "error-testlog-data", "", "No testlog data supplied", w)
+		return
+		// Check for parsing errors
+	case err != nil:
+		response.FormatStandardResponse(false, "error-testlog-json", "", err.Error(), w)
+		return
+	}
+
+	// Call the API with the user
+	syncLogHandler(w, user, true, request)
+}
+
+// APIListLog is the API method to list the unsync-ed factory test logs
+func APIListLog(w http.ResponseWriter, r *http.Request) {
+	// Validate the user and API key
+	user, err := request.CheckUserAPI(r)
+	if err != nil {
+		response.FormatStandardResponse(false, "error-auth", "", err.Error(), w)
+		return
+	}
+
+	// Call the API with the user
+	listHandler(w, user, true)
+}

--- a/service/testlog/handlers_adminapi_test.go
+++ b/service/testlog/handlers_adminapi_test.go
@@ -1,0 +1,102 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2018 Canonical Ltd
+ * License granted by Canonical Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package testlog_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/CanonicalLtd/serial-vault/datastore"
+	"github.com/CanonicalLtd/serial-vault/service"
+	"github.com/CanonicalLtd/serial-vault/service/response"
+	check "gopkg.in/check.v1"
+)
+
+type SyncTest struct {
+	Method      string
+	URL         string
+	Data        []byte
+	Code        int
+	Type        string
+	Permissions int
+	EnableAuth  bool
+	Success     bool
+	SkipJWT     bool
+	MockError   bool
+	Count       int
+}
+
+const exampleFile = "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4NCjx0ZXN0X3JlcG9ydD4NCiAgICA8dXV0cz4NCiAgICAgICAgPHV1dD4NCiAgICAgICAgICAgIDxzdW1tYXJ5Pg0KICAgICAgICAgICAgICAgIDxwYXJ0X251bWJlcj44NjAtMDAwMTQ8L3BhcnRfbnVtYmVyPg0KICAgICAgICAgICAgICAgIDxzZXJpYWxfbnVtYmVyPmU0YmY3Y2ViLWY3YWYtNDQyZS1iNzM0LTU0MzJlZjMzMDZiNTwvc2VyaWFsX251bWJlcj4NCiAgICAgICAgICAgICAgICA8b3BlcmF0aW9uPlZhbGlkYXRpb24gVGVzdDwvb3BlcmF0aW9uPg0KICAgICAgICAgICAgICAgIDxzdGFydGVkX2F0PjIwMTgtMDQtMDlUMTc6NDQ6MTYrMDI6MDA8L3N0YXJ0ZWRfYXQ+DQogICAgICAgICAgICAgICAgPGVuZGVkX2F0PjIwMTgtMDQtMDlUMTc6NDQ6MTYrMDI6MDA8L2VuZGVkX2F0Pg0KICAgICAgICAgICAgICAgIDxzdGF0dXM+RmFpbGVkPC9zdGF0dXM+DQogICAgICAgICAgICA8L3N1bW1hcnk+DQogICAgICAgICAgICA8dGVzdHM+DQogICAgICAgICAgICAgICAgPHRlc3Q+DQogICAgICAgICAgICAgICAgICAgIDxuYW1lPmZhY3RvcnlfY3B1L2lNWDZVTEw8L25hbWU+DQogICAgICAgICAgICAgICAgICAgIDxzdGF0dXM+ZmFpbGVkPC9zdGF0dXM+DQogICAgICAgICAgICAgICAgPC90ZXN0Pg0KICAgICAgICAgICAgICAgIDx0ZXN0Pg0KICAgICAgICAgICAgICAgICAgICA8bmFtZT5mYWN0b3J5X2V0aGVybmV0L2NhcmQtZGV0ZWN0PC9uYW1lPg0KICAgICAgICAgICAgICAgICAgICA8c3RhdHVzPmZhaWxlZDwvc3RhdHVzPg0KICAgICAgICAgICAgICAgIDwvdGVzdD4NCiAgICAgICAgICAgICAgICA8dGVzdD4NCiAgICAgICAgICAgICAgICAgICAgPG5hbWU+ZmFjdG9yeV9oZGQvZHJpdmUtY291bnQ8L25hbWU+DQogICAgICAgICAgICAgICAgICAgIDxzdGF0dXM+ZmFpbGVkPC9zdGF0dXM+DQogICAgICAgICAgICAgICAgPC90ZXN0Pg0KICAgICAgICAgICAgICAgIDx0ZXN0Pg0KICAgICAgICAgICAgICAgICAgICA8bmFtZT5mYWN0b3J5X1JBTS9zaXplPC9uYW1lPg0KICAgICAgICAgICAgICAgICAgICA8c3RhdHVzPnBhc3NlZDwvc3RhdHVzPg0KICAgICAgICAgICAgICAgIDwvdGVzdD4NCiAgICAgICAgICAgICAgICA8dGVzdD4NCiAgICAgICAgICAgICAgICAgICAgPG5hbWU+ZmFjdG9yeV9SVEM8L25hbWU+DQogICAgICAgICAgICAgICAgICAgIDxzdGF0dXM+ZmFpbGVkPC9zdGF0dXM+DQogICAgICAgICAgICAgICAgPC90ZXN0Pg0KICAgICAgICAgICAgICAgIDx0ZXN0Pg0KICAgICAgICAgICAgICAgICAgICA8bmFtZT5mYWN0b3J5X3VzYi91c2IyLXJvb3QtaHViLXByZXNlbnQ8L25hbWU+DQogICAgICAgICAgICAgICAgICAgIDxzdGF0dXM+cGFzc2VkPC9zdGF0dXM+DQogICAgICAgICAgICAgICAgPC90ZXN0Pg0KICAgICAgICAgICAgPC90ZXN0cz4NCjwvdXV0Pg0KPC91dXRzPg0KPC90ZXN0X3JlcG9ydD4="
+
+func (s *LogSuite) TestAPISyncHandler(c *check.C) {
+	tests := []SyncTest{
+		{"POST", "/api/testlog/1523460528_example_report.xml", []byte(""), 400, response.JSONHeader, datastore.SyncUser, false, false, false, false, 0},
+		{"POST", "/api/testlog/1523460528_example_report.xml", []byte("bad"), 400, response.JSONHeader, datastore.SyncUser, false, false, false, false, 0},
+		{"POST", "/api/testlog/1523460528_example_report.xml", []byte(exampleFile), 400, response.JSONHeader, 0, false, false, false, false, 0},
+		{"POST", "/api/testlog/1523460528_example_report.xml", []byte(exampleFile), 400, response.JSONHeader, datastore.SyncUser, true, false, false, true, 0},
+		{"POST", "/api/testlog/example_report.xml", []byte(exampleFile), 200, response.JSONHeader, datastore.SyncUser, true, true, false, false, 0},
+		{"POST", "/api/testlog/1523460528_example_report.xml", []byte(exampleFile), 200, response.JSONHeader, datastore.SyncUser, true, true, false, false, 0},
+		{"POST", "/api/testlog/1523460528_example_report.xml", []byte(exampleFile), 400, response.JSONHeader, datastore.Standard, true, false, false, false, 0},
+		{"POST", "/api/testlog/1523460528_example_report.xml", []byte(exampleFile), 400, response.JSONHeader, 0, true, false, false, false, 0},
+	}
+
+	for _, t := range tests {
+		if t.EnableAuth {
+			datastore.Environ.Config.EnableUserAuth = true
+		}
+		if t.MockError {
+			datastore.Environ.DB = &datastore.ErrorMockDB{}
+		}
+
+		w := sendAdminAPIRequest(t.Method, t.URL, bytes.NewReader(t.Data), t.Permissions, c)
+		c.Assert(w.Code, check.Equals, t.Code)
+		c.Assert(w.Header().Get("Content-Type"), check.Equals, t.Type)
+
+		result, err := response.ParseStandardResponse(w)
+		c.Assert(err, check.IsNil)
+		c.Assert(result.Success, check.Equals, t.Success)
+
+		datastore.Environ.Config.EnableUserAuth = false
+		datastore.Environ.DB = &datastore.MockDB{}
+	}
+}
+
+func sendAdminAPIRequest(method, url string, data io.Reader, permissions int, c *check.C) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(method, url, data)
+
+	switch permissions {
+	case datastore.SyncUser:
+		r.Header.Set("user", "sync")
+		r.Header.Set("api-key", "ValidAPIKey")
+	case datastore.Standard:
+		r.Header.Set("user", "user1")
+		r.Header.Set("api-key", "ValidAPIKey")
+	default:
+		break
+	}
+
+	service.AdminRouter().ServeHTTP(w, r)
+
+	return w
+}

--- a/service/testlog/handlers_adminapi_test.go
+++ b/service/testlog/handlers_adminapi_test.go
@@ -22,6 +22,7 @@ package testlog_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -49,15 +50,40 @@ type SyncTest struct {
 const exampleFile = "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4NCjx0ZXN0X3JlcG9ydD4NCiAgICA8dXV0cz4NCiAgICAgICAgPHV1dD4NCiAgICAgICAgICAgIDxzdW1tYXJ5Pg0KICAgICAgICAgICAgICAgIDxwYXJ0X251bWJlcj44NjAtMDAwMTQ8L3BhcnRfbnVtYmVyPg0KICAgICAgICAgICAgICAgIDxzZXJpYWxfbnVtYmVyPmU0YmY3Y2ViLWY3YWYtNDQyZS1iNzM0LTU0MzJlZjMzMDZiNTwvc2VyaWFsX251bWJlcj4NCiAgICAgICAgICAgICAgICA8b3BlcmF0aW9uPlZhbGlkYXRpb24gVGVzdDwvb3BlcmF0aW9uPg0KICAgICAgICAgICAgICAgIDxzdGFydGVkX2F0PjIwMTgtMDQtMDlUMTc6NDQ6MTYrMDI6MDA8L3N0YXJ0ZWRfYXQ+DQogICAgICAgICAgICAgICAgPGVuZGVkX2F0PjIwMTgtMDQtMDlUMTc6NDQ6MTYrMDI6MDA8L2VuZGVkX2F0Pg0KICAgICAgICAgICAgICAgIDxzdGF0dXM+RmFpbGVkPC9zdGF0dXM+DQogICAgICAgICAgICA8L3N1bW1hcnk+DQogICAgICAgICAgICA8dGVzdHM+DQogICAgICAgICAgICAgICAgPHRlc3Q+DQogICAgICAgICAgICAgICAgICAgIDxuYW1lPmZhY3RvcnlfY3B1L2lNWDZVTEw8L25hbWU+DQogICAgICAgICAgICAgICAgICAgIDxzdGF0dXM+ZmFpbGVkPC9zdGF0dXM+DQogICAgICAgICAgICAgICAgPC90ZXN0Pg0KICAgICAgICAgICAgICAgIDx0ZXN0Pg0KICAgICAgICAgICAgICAgICAgICA8bmFtZT5mYWN0b3J5X2V0aGVybmV0L2NhcmQtZGV0ZWN0PC9uYW1lPg0KICAgICAgICAgICAgICAgICAgICA8c3RhdHVzPmZhaWxlZDwvc3RhdHVzPg0KICAgICAgICAgICAgICAgIDwvdGVzdD4NCiAgICAgICAgICAgICAgICA8dGVzdD4NCiAgICAgICAgICAgICAgICAgICAgPG5hbWU+ZmFjdG9yeV9oZGQvZHJpdmUtY291bnQ8L25hbWU+DQogICAgICAgICAgICAgICAgICAgIDxzdGF0dXM+ZmFpbGVkPC9zdGF0dXM+DQogICAgICAgICAgICAgICAgPC90ZXN0Pg0KICAgICAgICAgICAgICAgIDx0ZXN0Pg0KICAgICAgICAgICAgICAgICAgICA8bmFtZT5mYWN0b3J5X1JBTS9zaXplPC9uYW1lPg0KICAgICAgICAgICAgICAgICAgICA8c3RhdHVzPnBhc3NlZDwvc3RhdHVzPg0KICAgICAgICAgICAgICAgIDwvdGVzdD4NCiAgICAgICAgICAgICAgICA8dGVzdD4NCiAgICAgICAgICAgICAgICAgICAgPG5hbWU+ZmFjdG9yeV9SVEM8L25hbWU+DQogICAgICAgICAgICAgICAgICAgIDxzdGF0dXM+ZmFpbGVkPC9zdGF0dXM+DQogICAgICAgICAgICAgICAgPC90ZXN0Pg0KICAgICAgICAgICAgICAgIDx0ZXN0Pg0KICAgICAgICAgICAgICAgICAgICA8bmFtZT5mYWN0b3J5X3VzYi91c2IyLXJvb3QtaHViLXByZXNlbnQ8L25hbWU+DQogICAgICAgICAgICAgICAgICAgIDxzdGF0dXM+cGFzc2VkPC9zdGF0dXM+DQogICAgICAgICAgICAgICAgPC90ZXN0Pg0KICAgICAgICAgICAgPC90ZXN0cz4NCjwvdXV0Pg0KPC91dXRzPg0KPC90ZXN0X3JlcG9ydD4="
 
 func (s *LogSuite) TestAPISyncHandler(c *check.C) {
+	t1 := datastore.TestLog{
+		Brand: "system", Model: "alder",
+		Filename: "example.xml", Data: exampleFile,
+	}
+	tLog1, err := json.Marshal(t1)
+	c.Assert(err, check.IsNil)
+
+	t2 := t1
+	t2.Data = ""
+	tLog2, err := json.Marshal(t2)
+	c.Assert(err, check.IsNil)
+
+	t3 := t1
+	t3.Data = "bad"
+	tLog3, err := json.Marshal(t3)
+	c.Assert(err, check.IsNil)
+
+	t4 := t1
+	t4.Filename = ""
+	t4.Data = ""
+	tLog4, err := json.Marshal(t4)
+	c.Assert(err, check.IsNil)
+
 	tests := []SyncTest{
-		{"POST", "/api/testlog/1523460528_example_report.xml", []byte(""), 400, response.JSONHeader, datastore.SyncUser, false, false, false, false, 0},
-		{"POST", "/api/testlog/1523460528_example_report.xml", []byte("bad"), 400, response.JSONHeader, datastore.SyncUser, false, false, false, false, 0},
-		{"POST", "/api/testlog/1523460528_example_report.xml", []byte(exampleFile), 400, response.JSONHeader, 0, false, false, false, false, 0},
-		{"POST", "/api/testlog/1523460528_example_report.xml", []byte(exampleFile), 400, response.JSONHeader, datastore.SyncUser, true, false, false, true, 0},
-		{"POST", "/api/testlog/example_report.xml", []byte(exampleFile), 200, response.JSONHeader, datastore.SyncUser, true, true, false, false, 0},
-		{"POST", "/api/testlog/1523460528_example_report.xml", []byte(exampleFile), 200, response.JSONHeader, datastore.SyncUser, true, true, false, false, 0},
-		{"POST", "/api/testlog/1523460528_example_report.xml", []byte(exampleFile), 400, response.JSONHeader, datastore.Standard, true, false, false, false, 0},
-		{"POST", "/api/testlog/1523460528_example_report.xml", []byte(exampleFile), 400, response.JSONHeader, 0, true, false, false, false, 0},
+		{"POST", "/api/testlog", []byte("bad"), 400, response.JSONHeader, datastore.SyncUser, false, false, false, false, 0},
+		{"POST", "/api/testlog", tLog2, 400, response.JSONHeader, datastore.SyncUser, false, false, false, false, 0},
+		{"POST", "/api/testlog", tLog3, 400, response.JSONHeader, datastore.SyncUser, false, false, false, false, 0},
+		{"POST", "/api/testlog", tLog4, 400, response.JSONHeader, datastore.SyncUser, false, false, false, false, 0},
+		{"POST", "/api/testlog", tLog1, 400, response.JSONHeader, 0, false, false, false, false, 0},
+		{"POST", "/api/testlog", tLog1, 400, response.JSONHeader, datastore.SyncUser, true, false, false, true, 0},
+		{"POST", "/api/testlog", tLog1, 200, response.JSONHeader, datastore.SyncUser, true, true, false, false, 0},
+		{"POST", "/api/testlog", tLog1, 200, response.JSONHeader, datastore.SyncUser, true, true, false, false, 0},
+		{"POST", "/api/testlog", tLog1, 400, response.JSONHeader, datastore.Standard, true, false, false, false, 0},
+		{"POST", "/api/testlog", tLog1, 400, response.JSONHeader, 0, true, false, false, false, 0},
 	}
 
 	for _, t := range tests {

--- a/service/testlog/handlers_testlog_test.go
+++ b/service/testlog/handlers_testlog_test.go
@@ -79,7 +79,7 @@ func sendSigningRequest(method, url string, data io.Reader, path, filename strin
 	return w
 }
 
-func (s *LogSuite) TestSubstoresHandler(c *check.C) {
+func (s *LogSuite) TestLogHandler(c *check.C) {
 	tests := []SuiteTest{
 		{"GET", "/testlog", nil, "", "", 200, "text/html; charset=utf-8", ""},
 		{"POST", "/testlog", nil, "", "", 400, response.JSONHeader, ""},


### PR DESCRIPTION
Adding the sync API for testlogs:
 - use testlog record in factory instead of the filesystem
 - add the brand/model to the web form (so permissions can be determined in the cloud)
 - add testlog (factory and cloud)
 - list testlog (cloud)

