### PR TITLE
Updated model and substore create API to return created object.

### DIFF
--- a/datastore/database.go
+++ b/datastore/database.go
@@ -114,7 +114,7 @@ type Datastore interface {
 	ListAllowedKeypairStatus(authorization User) ([]KeypairStatus, error)
 
 	CreateSubstoreTable() error
-	CreateAllowedSubstore(store Substore, authorization User) error
+	CreateAllowedSubstore(store Substore, authorization User) (Substore, error)
 	ListSubstores(accountID int, authorization User) ([]Substore, error)
 	UpdateAllowedSubstore(store Substore, authorization User) error
 	DeleteAllowedSubstore(storeID int, authorization User) (string, error)

--- a/datastore/mock_database.go
+++ b/datastore/mock_database.go
@@ -257,7 +257,7 @@ func keypairSystem() Keypair {
 
 // CreateAllowedModel mocks creating a new model.
 func (mdb *MockDB) CreateAllowedModel(model Model, authorization User) (Model, string, error) {
-	model = Model{ID: 7, BrandID: "system", Name: "the-model", KeypairID: 1, AuthorityID: "system", KeyID: "UytTqTvREVhx0tSfYC6KkFHmLWllIIZbQ3NsEG7OARrWuaXSRJyey0vjIQkTEvMO"}
+	model = Model{ID: 7, BrandID: model.BrandID, Name: model.Name, KeypairID: model.KeypairID, AuthorityID: "system", KeyID: "UytTqTvREVhx0tSfYC6KkFHmLWllIIZbQ3NsEG7OARrWuaXSRJyey0vjIQkTEvMO"}
 
 	return model, "", nil
 }
@@ -767,8 +767,10 @@ func (mdb *MockDB) CreateSubstoreTable() error {
 }
 
 // CreateAllowedSubstore mock to create a substore record
-func (mdb *MockDB) CreateAllowedSubstore(store Substore, authorization User) error {
-	return nil
+func (mdb *MockDB) CreateAllowedSubstore(store Substore, authorization User) (Substore, error) {
+	substore := Substore{ID: 1, AccountID: store.AccountID, FromModelID: store.FromModelID, Store: store.Store, SerialNumber: store.SerialNumber, ModelName: store.ModelName}
+
+	return substore, nil
 }
 
 // ListSubstores mock to list substore records
@@ -1293,8 +1295,8 @@ func (mdb *ErrorMockDB) CreateSubstoreTable() error {
 }
 
 // CreateAllowedSubstore mock to create a substore record
-func (mdb *ErrorMockDB) CreateAllowedSubstore(store Substore, authorization User) error {
-	return errors.New("Cannot create the sub-store model")
+func (mdb *ErrorMockDB) CreateAllowedSubstore(store Substore, authorization User) (Substore, error) {
+	return store, errors.New("Cannot create the sub-store model")
 }
 
 // ListSubstores mock to list substore records

--- a/datastore/substoreadapter.go
+++ b/datastore/substoreadapter.go
@@ -62,17 +62,17 @@ func (db *DB) UpdateAllowedSubstore(store Substore, authorization User) error {
 }
 
 // CreateAllowedSubstore creates a new model in case authorization is allowed to do it
-func (db *DB) CreateAllowedSubstore(store Substore, authorization User) error {
+func (db *DB) CreateAllowedSubstore(store Substore, authorization User) (Substore, error) {
 	// Validate the substore record
 	_, err := validateSubstore(store, "")
 	if err != nil {
-		return err
+		return store, err
 	}
 
 	// Validate that the user has access to the account
 	acc, err := db.GetAccountByID(store.AccountID, authorization)
 	if err != nil || acc.ID == 0 {
-		return errors.New("You do not have permissions to this account")
+		return store, errors.New("You do not have permissions to this account")
 	}
 
 	switch authorization.Role {
@@ -83,7 +83,7 @@ func (db *DB) CreateAllowedSubstore(store Substore, authorization User) error {
 	case Admin:
 		return db.createSubstore(store)
 	default:
-		return nil
+		return Substore{}, nil
 	}
 }
 

--- a/service/model/actions.go
+++ b/service/model/actions.go
@@ -38,8 +38,8 @@ type ListResponse struct {
 	Models       []datastore.Model `json:"models"`
 }
 
-// GetResponse is the JSON response from the API Get Model method
-type GetResponse struct {
+// InstanceResponse is the JSON response from the API Get/Post Model method
+type InstanceResponse struct {
 	Success      bool            `json:"success"`
 	ErrorCode    string          `json:"error_code"`
 	ErrorSubcode string          `json:"error_subcode"`
@@ -86,7 +86,7 @@ func getHandler(w http.ResponseWriter, user datastore.User, apiCall bool, modelI
 
 	// Return successful JSON response with the list of models
 	w.WriteHeader(http.StatusOK)
-	formatGetResponse(model, w)
+	formatInstanceResponse(model, w)
 }
 
 func updateHandler(w http.ResponseWriter, user datastore.User, apiCall bool, modelID int, mdl datastore.Model) {
@@ -145,7 +145,7 @@ func createHandler(w http.ResponseWriter, user datastore.User, apiCall bool, mdl
 		return
 	}
 
-	_, errorSubcode, err := datastore.Environ.DB.CreateAllowedModel(mdl, user)
+	allowedModel, errorSubcode, err := datastore.Environ.DB.CreateAllowedModel(mdl, user)
 	if err != nil {
 		response.FormatStandardResponse(false, "error-model-json", errorSubcode, "", w)
 		return
@@ -153,7 +153,7 @@ func createHandler(w http.ResponseWriter, user datastore.User, apiCall bool, mdl
 
 	// Return successful JSON response
 	w.WriteHeader(http.StatusOK)
-	response.FormatStandardResponse(true, "", "", "", w)
+	formatInstanceResponse(allowedModel, w)
 }
 
 func assertionHeaders(w http.ResponseWriter, user datastore.User, apiCall bool, assert datastore.ModelAssertion) {
@@ -193,8 +193,8 @@ func formatListResponse(models []datastore.Model, w http.ResponseWriter) error {
 	return nil
 }
 
-func formatGetResponse(model datastore.Model, w http.ResponseWriter) error {
-	response := GetResponse{Success: true, Model: model}
+func formatInstanceResponse(model datastore.Model, w http.ResponseWriter) error {
+	response := InstanceResponse{Success: true, Model: model}
 
 	// Encode the response as JSON
 	if err := json.NewEncoder(w).Encode(response); err != nil {

--- a/service/substore/handlers_adminapi_test.go
+++ b/service/substore/handlers_adminapi_test.go
@@ -99,6 +99,24 @@ func (s *SubstoreSuite) TestAPICreateUpdateDeleteHandler(c *check.C) {
 	}
 }
 
+func (s *SubstoreSuite) TestAPICreateHandlerReturnSubstore(c *check.C) {
+	substoreNew := datastore.Substore{AccountID: 1, FromModelID: 1, Store: "mybrand", SerialNumber: "a11112222", ModelName: "alder-mybrand"}
+	ssn, _ := json.Marshal(substoreNew)
+
+	w := sendAdminAPIRequest("POST", "/api/accounts/stores", bytes.NewReader(ssn), datastore.Admin, c)
+
+	result, err := parseInstanceResponse(w)
+	c.Assert(err, check.IsNil)
+	c.Assert(result.Success, check.Equals, true)
+
+	c.Assert(w.Code, check.Equals, 200)
+	c.Assert(w.Header().Get("Content-Type"), check.Equals, "application/json; charset=UTF-8")
+	// Substore is returned in the response, ID was set
+	c.Assert(result.Substore.ID > 0, check.Equals, true)
+	c.Assert(result.Substore.FromModelID, check.Equals, substoreNew.FromModelID)
+	c.Assert(result.Substore.SerialNumber, check.Equals, substoreNew.SerialNumber)
+}
+
 func sendAdminAPIRequest(method, url string, data io.Reader, permissions int, c *check.C) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(method, url, data)


### PR DESCRIPTION
Updated 'create' endpoints to return the created instance details.

Return created model and substore instances on a successful POST to the respective endpoints.

Model create: https://pastebin.canonical.com/p/48gzpyxcNP/
Substore create: https://pastebin.canonical.com/p/mxw6myR43Z/