### PR TITLE
Added admin endpoint to GET a substore by modelID and serial.

### DIFF
--- a/datastore/database.go
+++ b/datastore/database.go
@@ -114,7 +114,7 @@ type Datastore interface {
 	ListAllowedKeypairStatus(authorization User) ([]KeypairStatus, error)
 
 	CreateSubstoreTable() error
-	CreateAllowedSubstore(store Substore, authorization User) error
+	CreateAllowedSubstore(store Substore, authorization User) (Substore, error)
 	ListSubstores(accountID int, authorization User) ([]Substore, error)
 	UpdateAllowedSubstore(store Substore, authorization User) error
 	DeleteAllowedSubstore(storeID int, authorization User) (string, error)

--- a/datastore/database.go
+++ b/datastore/database.go
@@ -118,6 +118,7 @@ type Datastore interface {
 	ListSubstores(accountID int, authorization User) ([]Substore, error)
 	UpdateAllowedSubstore(store Substore, authorization User) error
 	DeleteAllowedSubstore(storeID int, authorization User) (string, error)
+	GetAllowedSubstore(fromModelID int, serialNumber string, authorization User) (Substore, error)
 	GetSubstore(fromModelID int, serialNumber string) (Substore, error)
 	GetSubstoreModel(brand, model, serialNumber string) (Substore, error)
 

--- a/datastore/mock_database.go
+++ b/datastore/mock_database.go
@@ -257,7 +257,7 @@ func keypairSystem() Keypair {
 
 // CreateAllowedModel mocks creating a new model.
 func (mdb *MockDB) CreateAllowedModel(model Model, authorization User) (Model, string, error) {
-	model = Model{ID: 7, BrandID: "system", Name: "the-model", KeypairID: 1, AuthorityID: "system", KeyID: "UytTqTvREVhx0tSfYC6KkFHmLWllIIZbQ3NsEG7OARrWuaXSRJyey0vjIQkTEvMO"}
+	model = Model{ID: 7, BrandID: model.BrandID, Name: model.Name, KeypairID: model.KeypairID, AuthorityID: "system", KeyID: "UytTqTvREVhx0tSfYC6KkFHmLWllIIZbQ3NsEG7OARrWuaXSRJyey0vjIQkTEvMO"}
 
 	return model, "", nil
 }
@@ -767,8 +767,10 @@ func (mdb *MockDB) CreateSubstoreTable() error {
 }
 
 // CreateAllowedSubstore mock to create a substore record
-func (mdb *MockDB) CreateAllowedSubstore(store Substore, authorization User) error {
-	return nil
+func (mdb *MockDB) CreateAllowedSubstore(store Substore, authorization User) (Substore, error) {
+	substore := Substore{ID: 1, AccountID: store.AccountID, FromModelID: store.FromModelID, Store: store.Store, SerialNumber: store.SerialNumber, ModelName: store.ModelName}
+
+	return substore, nil
 }
 
 // ListSubstores mock to list substore records
@@ -1293,8 +1295,8 @@ func (mdb *ErrorMockDB) CreateSubstoreTable() error {
 }
 
 // CreateAllowedSubstore mock to create a substore record
-func (mdb *ErrorMockDB) CreateAllowedSubstore(store Substore, authorization User) error {
-	return errors.New("Cannot create the sub-store model")
+func (mdb *ErrorMockDB) CreateAllowedSubstore(store Substore, authorization User) (Substore, error) {
+	return store, errors.New("Cannot create the sub-store model")
 }
 
 // ListSubstores mock to list substore records

--- a/datastore/mock_database.go
+++ b/datastore/mock_database.go
@@ -810,6 +810,11 @@ func (mdb *MockDB) GetSubstoreModel(brand, model, serialNumber string) (Substore
 	return mdb.GetSubstore(1, serialNumber)
 }
 
+// GetAllowedSubstore mock to get a substore record
+func (mdb *MockDB) GetAllowedSubstore(fromModelID int, serialNumber string, authorization User) (Substore, error) {
+	return mdb.GetSubstore(fromModelID, serialNumber)
+}
+
 // CreateTestLog mock to create a test log
 func (mdb *MockDB) CreateTestLog(testLog TestLog) error {
 	return nil
@@ -1329,6 +1334,11 @@ func (mdb *ErrorMockDB) GetSubstore(fromModelID int, serialNumber string) (Subst
 // GetSubstoreModel mock to get a substore record
 func (mdb *ErrorMockDB) GetSubstoreModel(brand, model, serialNumber string) (Substore, error) {
 	return Substore{}, errors.New("Cannot get the sub-store model")
+}
+
+// GetAllowedSubstore mock to get a substore record
+func (mdb *ErrorMockDB) GetAllowedSubstore(fromModelID int, serialNumber string, authorization User) (Substore, error) {
+	return mdb.GetSubstore(fromModelID, serialNumber)
 }
 
 // CreateTestLog mock to create a test log

--- a/datastore/substoreadapter.go
+++ b/datastore/substoreadapter.go
@@ -41,6 +41,20 @@ func (db *DB) ListSubstores(accountID int, authorization User) ([]Substore, erro
 	}
 }
 
+// GetAllowedSubstore return the sub-store if the user is authorized to see it
+func (db *DB) GetAllowedSubstore(modelID int, serial string, authorization User) (Substore, error) {
+	switch authorization.Role {
+	case Invalid: // Authentication disabled
+		fallthrough
+	case Superuser:
+		return db.GetSubstore(modelID, serial)
+	case Admin:
+		return db.GetSubstoreFilteredByUser(modelID, serial, authorization.Username)
+	default:
+		return Substore{}, nil
+	}
+}
+
 // UpdateAllowedSubstore updates the sub-store if authorization is allowed to do it
 func (db *DB) UpdateAllowedSubstore(store Substore, authorization User) error {
 

--- a/datastore/substoreadapter.go
+++ b/datastore/substoreadapter.go
@@ -62,17 +62,17 @@ func (db *DB) UpdateAllowedSubstore(store Substore, authorization User) error {
 }
 
 // CreateAllowedSubstore creates a new model in case authorization is allowed to do it
-func (db *DB) CreateAllowedSubstore(store Substore, authorization User) error {
+func (db *DB) CreateAllowedSubstore(store Substore, authorization User) (Substore, error) {
 	// Validate the substore record
 	_, err := validateSubstore(store, "")
 	if err != nil {
-		return err
+		return store, err
 	}
 
 	// Validate that the user has access to the account
 	acc, err := db.GetAccountByID(store.AccountID, authorization)
 	if err != nil || acc.ID == 0 {
-		return errors.New("You do not have permissions to this account")
+		return store, errors.New("You do not have permissions to this account")
 	}
 
 	switch authorization.Role {
@@ -83,7 +83,7 @@ func (db *DB) CreateAllowedSubstore(store Substore, authorization User) error {
 	case Admin:
 		return db.createSubstore(store)
 	default:
-		return nil
+		return Substore{}, nil
 	}
 }
 

--- a/service/model/actions.go
+++ b/service/model/actions.go
@@ -38,8 +38,8 @@ type ListResponse struct {
 	Models       []datastore.Model `json:"models"`
 }
 
-// GetResponse is the JSON response from the API Get Model method
-type GetResponse struct {
+// InstanceResponse is the JSON response from the API Get/Post Model method
+type InstanceResponse struct {
 	Success      bool            `json:"success"`
 	ErrorCode    string          `json:"error_code"`
 	ErrorSubcode string          `json:"error_subcode"`
@@ -86,7 +86,7 @@ func getHandler(w http.ResponseWriter, user datastore.User, apiCall bool, modelI
 
 	// Return successful JSON response with the list of models
 	w.WriteHeader(http.StatusOK)
-	formatGetResponse(model, w)
+	formatInstanceResponse(model, w)
 }
 
 func updateHandler(w http.ResponseWriter, user datastore.User, apiCall bool, modelID int, mdl datastore.Model) {
@@ -145,7 +145,7 @@ func createHandler(w http.ResponseWriter, user datastore.User, apiCall bool, mdl
 		return
 	}
 
-	_, errorSubcode, err := datastore.Environ.DB.CreateAllowedModel(mdl, user)
+	allowedModel, errorSubcode, err := datastore.Environ.DB.CreateAllowedModel(mdl, user)
 	if err != nil {
 		response.FormatStandardResponse(false, "error-model-json", errorSubcode, "", w)
 		return
@@ -153,7 +153,7 @@ func createHandler(w http.ResponseWriter, user datastore.User, apiCall bool, mdl
 
 	// Return successful JSON response
 	w.WriteHeader(http.StatusOK)
-	response.FormatStandardResponse(true, "", "", "", w)
+	formatInstanceResponse(allowedModel, w)
 }
 
 func assertionHeaders(w http.ResponseWriter, user datastore.User, apiCall bool, assert datastore.ModelAssertion) {
@@ -193,8 +193,8 @@ func formatListResponse(models []datastore.Model, w http.ResponseWriter) error {
 	return nil
 }
 
-func formatGetResponse(model datastore.Model, w http.ResponseWriter) error {
-	response := GetResponse{Success: true, Model: model}
+func formatInstanceResponse(model datastore.Model, w http.ResponseWriter) error {
+	response := InstanceResponse{Success: true, Model: model}
 
 	// Encode the response as JSON
 	if err := json.NewEncoder(w).Encode(response); err != nil {

--- a/service/router.go
+++ b/service/router.go
@@ -154,6 +154,7 @@ func AdminRouter() *mux.Router {
 	router.Handle("/api/accounts/stores/{id:[0-9]+}", Middleware(http.HandlerFunc(substore.APIUpdate))).Methods("PUT")
 	router.Handle("/api/accounts/stores/{id:[0-9]+}", Middleware(http.HandlerFunc(substore.APIDelete))).Methods("DELETE")
 	router.Handle("/api/accounts/stores", Middleware(http.HandlerFunc(substore.APICreate))).Methods("POST")
+	router.Handle("/api/accounts/stores/{modelID:[0-9]+}/{serial}", Middleware(http.HandlerFunc(substore.APIGet))).Methods("GET")
 	router.Handle("/api/assertions/checkserial", Middleware(http.HandlerFunc(assertion.APIValidateSerial))).Methods("POST")
 	router.Handle("/api/assertions", Middleware(http.HandlerFunc(assertion.APISystemUser))).Methods("POST")
 	router.Handle("/api/models/{id:[0-9]+}", Middleware(http.HandlerFunc(model.APIGet))).Methods("GET")

--- a/service/substore/actions.go
+++ b/service/substore/actions.go
@@ -156,3 +156,24 @@ func deleteHandler(w http.ResponseWriter, user datastore.User, apiCall bool, sto
 	w.WriteHeader(http.StatusOK)
 	response.FormatStandardResponse(true, "", "", "", w)
 }
+
+// getHandler is the API method to get a substore given FromModelID and SerialNumber
+func getHandler(w http.ResponseWriter, user datastore.User, apiCall bool, modelID int, serial string) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+
+	err := auth.CheckUserPermissions(user, datastore.Admin, apiCall)
+	if err != nil {
+		response.FormatStandardResponse(false, "error-auth", "", "", w)
+		return
+	}
+
+	store, err := datastore.Environ.DB.GetAllowedSubstore(modelID, serial, user)
+	if err != nil {
+		response.FormatStandardResponse(false, "error-stores-json", "", err.Error(), w)
+		return
+	}
+
+	// Return successful JSON response with the list of models
+	w.WriteHeader(http.StatusOK)
+	formatInstanceResponse(store, w)
+}

--- a/service/substore/handlers_adminapi.go
+++ b/service/substore/handlers_adminapi.go
@@ -139,3 +139,26 @@ func APIDelete(w http.ResponseWriter, r *http.Request) {
 	// Call the API with the user
 	deleteHandler(w, user, true, storeID)
 }
+
+// APIGet is the API method to get a particular instance of a substore
+func APIGet(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+
+	// Validate the user and API key
+	user, err := request.CheckUserAPI(r)
+	if err != nil {
+		response.FormatStandardResponse(false, "error-auth", "", err.Error(), w)
+		return
+	}
+
+	vars := mux.Vars(r)
+	serial := vars["serial"]
+	modelID, err := strconv.Atoi(vars["modelID"])
+	if err != nil {
+		response.FormatStandardResponse(false, "error-invalid-model", "", err.Error(), w)
+		return
+	}
+
+	// Call the API with the user
+	getHandler(w, user, true, modelID, serial)
+}

--- a/service/substore/handlers_adminapi_test.go
+++ b/service/substore/handlers_adminapi_test.go
@@ -99,6 +99,24 @@ func (s *SubstoreSuite) TestAPICreateUpdateDeleteHandler(c *check.C) {
 	}
 }
 
+func (s *SubstoreSuite) TestAPICreateHandlerReturnSubstore(c *check.C) {
+	substoreNew := datastore.Substore{AccountID: 1, FromModelID: 1, Store: "mybrand", SerialNumber: "a11112222", ModelName: "alder-mybrand"}
+	ssn, _ := json.Marshal(substoreNew)
+
+	w := sendAdminAPIRequest("POST", "/api/accounts/stores", bytes.NewReader(ssn), datastore.Admin, c)
+
+	result, err := parseInstanceResponse(w)
+	c.Assert(err, check.IsNil)
+	c.Assert(result.Success, check.Equals, true)
+
+	c.Assert(w.Code, check.Equals, 200)
+	c.Assert(w.Header().Get("Content-Type"), check.Equals, "application/json; charset=UTF-8")
+	// Substore is returned in the response, ID was set
+	c.Assert(result.Substore.ID > 0, check.Equals, true)
+	c.Assert(result.Substore.FromModelID, check.Equals, substoreNew.FromModelID)
+	c.Assert(result.Substore.SerialNumber, check.Equals, substoreNew.SerialNumber)
+}
+
 func sendAdminAPIRequest(method, url string, data io.Reader, permissions int, c *check.C) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(method, url, data)


### PR DESCRIPTION
Reproduces auth logic from other endpoints, checking user role and access.
Endpoint only enabled for the admin API.

Built on top of #228.

Example: https://pastebin.canonical.com/p/VKzCVp2hmR/