### PR TITLE
Changed logger configuration for better monnitoring

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -21,9 +21,9 @@ package account
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
+	"github.com/CanonicalLtd/serial-vault/service/log"
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/store"
@@ -45,7 +45,7 @@ func CacheAccountAssertions(env *datastore.Env) {
 	// Get the active signing-keys from the database. This operation is not filtered by authorization
 	keypairs, err := env.DB.ListAllowedKeypairs(datastore.User{})
 	if err != nil {
-		log.Fatalf("Error retrieving the keypairs: %v\n", err)
+		log.Fatalf("Error retrieving the keypairs: %v", err)
 	}
 
 	// Get the account/account-key assertions from the snap store and cache them locally
@@ -103,7 +103,7 @@ func CacheAccounts(env *datastore.Env) {
 	// Get the accounts from the database. This operation is not filtered by authorization
 	accounts, err := env.DB.ListAllowedAccounts(datastore.User{})
 	if err != nil {
-		log.Fatalf("Error retrieving the keypairs: %v\n", err)
+		log.Fatalf("Error retrieving the keypairs: %v", err)
 	}
 
 	// Get the account assertions from the snap store and cache them locally

--- a/cmd/serial-vault/main.go
+++ b/cmd/serial-vault/main.go
@@ -30,13 +30,17 @@ import (
 	logging "github.com/op/go-logging"
 )
 
+func init() {
+	svlog.InitLogger(logging.INFO)
+}
+
 func main() {
 	datastore.Environ = &datastore.Env{}
 	// Parse the command line arguments
 	config.ParseArgs()
 	err := config.ReadConfig(&datastore.Environ.Config, config.SettingsFile)
 	if err != nil {
-		log.Fatalf("Error parsing the config file: %v", err)
+		svlog.Fatalf("Error parsing the config file: %v", err)
 	}
 
 	// Open the connection to the local database
@@ -45,7 +49,7 @@ func main() {
 	// Opening the keypair manager to create the signing database
 	err = datastore.OpenKeyStore(datastore.Environ.Config)
 	if err != nil {
-		log.Fatalf("Error initializing the signing-key database: %v", err)
+		svlog.Fatalf("Error initializing the signing-key database: %v", err)
 	}
 
 	var handler http.Handler
@@ -62,7 +66,6 @@ func main() {
 		address = ":8080"
 	}
 
-	svlog.InitLogger(logging.INFO)
 	svlog.Infof("Starting service on port %s", address)
 	log.Fatal(http.ListenAndServe(address, handler))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,8 @@ package config
 import (
 	"flag"
 	"io/ioutil"
-	"log"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"gopkg.in/yaml.v2"
 )

--- a/crypt/crypto.go
+++ b/crypt/crypto.go
@@ -28,8 +28,9 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
-	"log"
 	"strings"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/snapcore/snapd/asserts"
 	"golang.org/x/crypto/openpgp/armor"

--- a/datastore/accountmanager.go
+++ b/datastore/accountmanager.go
@@ -21,7 +21,8 @@ package datastore
 
 import (
 	"database/sql"
-	"log"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 )
 
 const createAccountTableSQL = `

--- a/datastore/database_pg.go
+++ b/datastore/database_pg.go
@@ -22,8 +22,8 @@ package datastore
 
 import (
 	"database/sql"
-	"log"
 
+	"github.com/CanonicalLtd/serial-vault/service/log"
 	_ "github.com/lib/pq" // postgresql driver
 )
 
@@ -32,13 +32,13 @@ func openPostgreSQLDatabase(driver, dataSource string) {
 	// Open the database connection
 	db, err := sql.Open(driver, dataSource)
 	if err != nil {
-		log.Fatalf("Error opening the database: %v\n", err)
+		log.Fatalf("Error opening the database: %v", err)
 	}
 
 	// Check that we have a valid database connection
 	err = db.Ping()
 	if err != nil {
-		log.Fatalf("Error accessing the database: %v\n", err)
+		log.Fatalf("Error accessing the database: %v", err)
 	}
 
 	Environ.DB = &DB{db}

--- a/datastore/database_sqlite.go
+++ b/datastore/database_sqlite.go
@@ -22,7 +22,8 @@ package datastore
 
 import (
 	"database/sql"
-	"log"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	_ "github.com/mattn/go-sqlite3" // sqlite driver
 )

--- a/datastore/dbkeypairoperator.go
+++ b/datastore/dbkeypairoperator.go
@@ -24,7 +24,8 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
-	"log"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/crypt"
 )

--- a/datastore/keypair.go
+++ b/datastore/keypair.go
@@ -19,8 +19,9 @@ package datastore
 
 import (
 	"encoding/base64"
-	"log"
 	"os/exec"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/snapcore/snapd/asserts"
 )

--- a/datastore/keypairmanager.go
+++ b/datastore/keypairmanager.go
@@ -23,7 +23,8 @@ package datastore
 import (
 	"database/sql"
 	"errors"
-	"log"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 )
 
 const createKeypairTableSQL = `

--- a/datastore/keypairstatusmanager.go
+++ b/datastore/keypairstatusmanager.go
@@ -21,7 +21,8 @@ package datastore
 
 import (
 	"database/sql"
-	"log"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 )
 
 const createKeypairStatusTableSQL = `

--- a/datastore/modeladapter.go
+++ b/datastore/modeladapter.go
@@ -22,9 +22,10 @@ package datastore
 import (
 	"errors"
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/random"
 )

--- a/datastore/modelmanager.go
+++ b/datastore/modelmanager.go
@@ -23,7 +23,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"log"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 )
 
 const createModelTableSQL = `

--- a/datastore/noncemanager.go
+++ b/datastore/noncemanager.go
@@ -24,9 +24,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"strconv"
 	"time"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/random"
 )

--- a/datastore/openidmanager.go
+++ b/datastore/openidmanager.go
@@ -21,8 +21,9 @@ package datastore
 
 import (
 	"errors"
-	"log"
 	"time"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 )
 
 // OpenidNonceMaxAge is the maximum age of stored nonces. Any nonces older

--- a/datastore/settingsmanager.go
+++ b/datastore/settingsmanager.go
@@ -21,7 +21,8 @@ package datastore
 
 import (
 	"errors"
-	"log"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 )
 
 // Understood settings codes

--- a/datastore/signinglogmanager.go
+++ b/datastore/signinglogmanager.go
@@ -22,8 +22,9 @@ package datastore
 import (
 	"database/sql"
 	"errors"
-	"log"
 	"time"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 )
 
 const createSigningLogTableSQL = `

--- a/datastore/testlogmanager.go
+++ b/datastore/testlogmanager.go
@@ -23,8 +23,9 @@ package datastore
 import (
 	"database/sql"
 	"errors"
-	"log"
 	"time"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 )
 
 const createTestLogTableSQL = `

--- a/datastore/tpm20command.go
+++ b/datastore/tpm20command.go
@@ -20,8 +20,9 @@
 package datastore
 
 import (
-	"log"
 	"os/exec"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 )
 
 // TPM20Command is an interface for wrapping the TPM2.0 shell commands

--- a/datastore/tpm20command_test.go
+++ b/datastore/tpm20command_test.go
@@ -21,8 +21,9 @@ package datastore
 
 import (
 	"io/ioutil"
-	"log"
 	"testing"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 )
 
 type mockTPM20Command struct{}

--- a/datastore/tpm20keypairoperator.go
+++ b/datastore/tpm20keypairoperator.go
@@ -22,8 +22,9 @@ package datastore
 import (
 	"encoding/base64"
 	"io/ioutil"
-	"log"
 	"os"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/crypt"
 )

--- a/datastore/tpm2manager.go
+++ b/datastore/tpm2manager.go
@@ -21,7 +21,8 @@ package datastore
 
 import (
 	"io/ioutil"
-	"log"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 )
 
 // TPM2InitializeKeystore initializes the TPM 2.0 module by taking ownership of the module

--- a/datastore/usermanager.go
+++ b/datastore/usermanager.go
@@ -22,7 +22,8 @@ package datastore
 import (
 	"database/sql"
 	"errors"
-	"log"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 )
 
 const createUserTableSQL = `

--- a/manage/client.go
+++ b/manage/client.go
@@ -26,9 +26,10 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/crypt"
 	"github.com/CanonicalLtd/serial-vault/service/response"

--- a/manage/database.go
+++ b/manage/database.go
@@ -22,7 +22,8 @@ package manage
 
 import (
 	"fmt"
-	"log"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 )

--- a/manage/database_test.go
+++ b/manage/database_test.go
@@ -20,7 +20,7 @@
 package manage
 
 import (
-	"log"
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/config"
 	"github.com/CanonicalLtd/serial-vault/datastore"

--- a/service/account/actions.go
+++ b/service/account/actions.go
@@ -23,8 +23,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/service/auth"

--- a/service/app/handlers_app.go
+++ b/service/app/handlers_app.go
@@ -20,10 +20,11 @@
 package app
 
 import (
-	"log"
 	"net/http"
 	"strings"
 	"text/template"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 )

--- a/service/assertion/actions_check.go
+++ b/service/assertion/actions_check.go
@@ -21,14 +21,14 @@
 package assertion
 
 import (
-	"log"
 	"net/http"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/snapcore/snapd/asserts"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/service/auth"
-	svlog "github.com/CanonicalLtd/serial-vault/service/log"
 	"github.com/CanonicalLtd/serial-vault/service/response"
 )
 
@@ -64,7 +64,7 @@ func validateAssertionAction(w http.ResponseWriter, authUser datastore.User, api
 	// Check for a sub-store model for the pivot
 	if _, err = datastore.Environ.DB.GetSubstoreModel(assertion.HeaderString("brand-id"), assertion.HeaderString("model"), assertion.HeaderString("serial")); err != nil {
 		log.Println(err)
-		svlog.Message("CHECK", "invalid-substore", "Cannot find sub-store model")
+		log.Message("CHECK", "invalid-substore", "Cannot find sub-store model")
 		response.FormatStandardResponse(false, response.ErrorInvalidSubstore.Code, "", response.ErrorInvalidSubstore.Message, w)
 		return
 	}

--- a/service/assertion/handlers_adminapi.go
+++ b/service/assertion/handlers_adminapi.go
@@ -25,7 +25,7 @@ import (
 	"io"
 	"net/http"
 
-	svlog "github.com/CanonicalLtd/serial-vault/service/log"
+	"github.com/CanonicalLtd/serial-vault/service/log"
 	"github.com/CanonicalLtd/serial-vault/service/request"
 	"github.com/CanonicalLtd/serial-vault/service/response"
 	"github.com/snapcore/snapd/asserts"
@@ -83,17 +83,17 @@ func parseSerialAssertion(r *http.Request) (asserts.Assertion, response.ErrorRes
 	dec := asserts.NewDecoder(r.Body)
 	assertion, err := dec.Decode()
 	if err == io.EOF {
-		svlog.Message("CHECK", response.ErrorInvalidAssertion.Code, response.ErrorEmptyData.Message)
+		log.Message("CHECK", response.ErrorInvalidAssertion.Code, response.ErrorEmptyData.Message)
 		return nil, response.ErrorEmptyData
 	}
 	if err != nil {
-		svlog.Message("CHECK", response.ErrorInvalidAssertion.Code, err.Error())
+		log.Message("CHECK", response.ErrorInvalidAssertion.Code, err.Error())
 		return nil, response.ErrorResponse{Success: false, Code: "decode-assertion", Message: err.Error(), StatusCode: http.StatusBadRequest}
 	}
 
 	// Check that we have a serial assertion (the details will have been validated by Decode call)
 	if assertion.Type() != asserts.SerialType {
-		svlog.Message("CHECK", response.ErrorInvalidType.Code, response.ErrorInvalidType.Message)
+		log.Message("CHECK", response.ErrorInvalidType.Code, response.ErrorInvalidType.Message)
 		return nil, response.ErrorInvalidType
 	}
 	return assertion, response.ErrorResponse{Success: true}

--- a/service/auth/middleware.go
+++ b/service/auth/middleware.go
@@ -21,8 +21,9 @@ package auth
 
 import (
 	"errors"
-	"log"
 	"net/http"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/usso"

--- a/service/keypair/actions.go
+++ b/service/keypair/actions.go
@@ -24,9 +24,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/service/auth"

--- a/service/log/log.go
+++ b/service/log/log.go
@@ -20,7 +20,7 @@
 package log
 
 import (
-	"log"
+	"fmt"
 	"os"
 
 	logging "github.com/op/go-logging"
@@ -29,7 +29,8 @@ import (
 // Message logs a message in a fixed format so it can be analyzed by log handlers
 // e.g. "METHOD CODE descriptive reason"
 func Message(method, code, reason string) {
-	log.Printf("M: %s %s %s\n", method, code, reason)
+	msg := fmt.Sprintf("%s method=%s, code=%s", reason, method, code)
+	Error(msg)
 }
 
 var l = logging.MustGetLogger("serialvault")
@@ -48,7 +49,6 @@ func InitLogger(level logging.Level) {
 
 	backendLeveled := logging.AddModuleLevel(backendFormatter)
 	backendLeveled.SetLevel(level, "")
-
 	logging.SetBackend(backendLeveled)
 }
 

--- a/service/log/log.go
+++ b/service/log/log.go
@@ -29,7 +29,7 @@ import (
 // Message logs a message in a fixed format so it can be analyzed by log handlers
 // e.g. "METHOD CODE descriptive reason"
 func Message(method, code, reason string) {
-	msg := fmt.Sprintf("%s method=%s, code=%s", reason, method, code)
+	msg := fmt.Sprintf("%s: method=%s, code=%s", reason, method, code)
 	Error(msg)
 }
 
@@ -54,60 +54,60 @@ func InitLogger(level logging.Level) {
 
 // Fatalf calls logger in fatal level with format
 func Fatalf(format string, args ...interface{}) {
-	l.Fatalf(format, args)
+	l.Fatalf(format, args...)
 }
 
 // Fatal calls logger in fatal level
 func Fatal(args ...interface{}) {
-	l.Fatal(args)
+	l.Fatal(args...)
 }
 
 // Errorf calls logger in eror level with format
 func Errorf(format string, args ...interface{}) {
-	l.Errorf(format, args)
+	l.Errorf(format, args...)
 }
 
 // Error calls logger in error level
 func Error(args ...interface{}) {
-	l.Error(args)
+	l.Error(args...)
 }
 
 // Warningf calls logger in warning level with format
 func Warningf(format string, args ...interface{}) {
-	l.Warningf(format, args)
+	l.Warningf(format, args...)
 }
 
 // Warning calls logger in warning level
 func Warning(args ...interface{}) {
-	l.Warning(args)
+	l.Warning(args...)
 }
 
 // Infof calls logger in info level with format
 func Infof(format string, args ...interface{}) {
-	l.Infof(format, args)
+	l.Infof(format, args...)
 }
 
 // Info calls logger in info level
 func Info(args ...interface{}) {
-	l.Info(args)
+	l.Info(args...)
 }
 
 // Debugf calls logger in debug level with format
 func Debugf(format string, args ...interface{}) {
-	l.Debugf(format, args)
+	l.Debugf(format, args...)
 }
 
 // Debug calls logger in debug level
 func Debug(args ...interface{}) {
-	l.Debug(args)
+	l.Debug(args...)
 }
 
 // Printf calls logger in info level with format
 func Printf(format string, args ...interface{}) {
-	l.Infof(format, args)
+	Errorf(format, args...)
 }
 
 // Println calls logger in info level
 func Println(args ...interface{}) {
-	l.Info(args)
+	Error(args...)
 }

--- a/service/log/log.go
+++ b/service/log/log.go
@@ -29,17 +29,20 @@ import (
 // Message logs a message in a fixed format so it can be analyzed by log handlers
 // e.g. "METHOD CODE descriptive reason"
 func Message(method, code, reason string) {
-	log.Printf("%s %s %s\n", method, code, reason)
+	log.Printf("M: %s %s %s\n", method, code, reason)
 }
 
 var l = logging.MustGetLogger("serialvault")
 
 // InitLogger initializes logger for backend with the specified level
+// format = '%(asctime)s.%(msecs)03dZ %(levelname)s %(name)s "%(message)s"'
+// datefmt = "%Y-%m-%d %H:%M:%S"
+// 2016-07-14 01:02:03.456Z INFO app "hello"
 func InitLogger(level logging.Level) {
 	backend := logging.NewLogBackend(os.Stderr, "", 0)
 
 	format := logging.MustStringFormatter(
-		`%{color}%{time:2006/01/02 15:04:05.000} %{module} ▶ %{level:.4s} %{id:03x}%{color:reset} %{message}`,
+		`%{color}%{time:2006-01-02 15:04:05Z} %{level} %{module}%{color:reset} %{message:q}`,
 	)
 	backendFormatter := logging.NewBackendFormatter(backend, format)
 
@@ -47,6 +50,16 @@ func InitLogger(level logging.Level) {
 	backendLeveled.SetLevel(level, "")
 
 	logging.SetBackend(backendLeveled)
+}
+
+// Fatalf calls logger in fatal level with format
+func Fatalf(format string, args ...interface{}) {
+	l.Fatalf(format, args)
+}
+
+// Fatal calls logger in fatal level
+func Fatal(args ...interface{}) {
+	l.Fatal(args)
 }
 
 // Errorf calls logger in eror level with format
@@ -87,4 +100,14 @@ func Debugf(format string, args ...interface{}) {
 // Debug calls logger in debug level
 func Debug(args ...interface{}) {
 	l.Debug(args)
+}
+
+// Printf calls logger in info level with format
+func Printf(format string, args ...interface{}) {
+	l.Infof(format, args)
+}
+
+// Println calls logger in info level
+func Println(args ...interface{}) {
+	l.Info(args)
 }

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -21,10 +21,11 @@ package service
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/service/response"
@@ -33,12 +34,7 @@ import (
 
 // Logger Handle logging for the web service
 func Logger(start time.Time, r *http.Request) {
-	log.Printf(
-		"%s\t%s\t%s",
-		r.Method,
-		r.RequestURI,
-		time.Since(start),
-	)
+	log.Printf("%s\t%s\t%s", r.Method, r.RequestURI, time.Since(start))
 }
 
 // ErrorHandler is a standard error handler middleware that generates the error response

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -21,24 +21,20 @@ package service
 
 import (
 	"encoding/json"
-	"log"
+
 	"net/http"
 	"os"
 	"time"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
+	"github.com/CanonicalLtd/serial-vault/service/log"
 	"github.com/CanonicalLtd/serial-vault/service/response"
 	"github.com/gorilla/csrf"
 )
 
 // Logger Handle logging for the web service
 func Logger(start time.Time, r *http.Request) {
-	log.Printf(
-		"%s\t%s\t%s",
-		r.Method,
-		r.URL.Path,
-		time.Since(start),
-	)
+	log.Infof("%s %s %s", r.Method, r.URL.Path, time.Since(start))
 }
 
 // ErrorHandler is a standard error handler middleware that generates the error response

--- a/service/middleware.go
+++ b/service/middleware.go
@@ -21,11 +21,10 @@ package service
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"os"
 	"time"
-
-	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/service/response"
@@ -34,7 +33,12 @@ import (
 
 // Logger Handle logging for the web service
 func Logger(start time.Time, r *http.Request) {
-	log.Printf("%s\t%s\t%s", r.Method, r.RequestURI, time.Since(start))
+	log.Printf(
+		"%s\t%s\t%s",
+		r.Method,
+		r.URL.Path,
+		time.Since(start),
+	)
 }
 
 // ErrorHandler is a standard error handler middleware that generates the error response

--- a/service/model/actions.go
+++ b/service/model/actions.go
@@ -21,8 +21,9 @@ package model
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/service/auth"

--- a/service/pivot/handlers_pivot.go
+++ b/service/pivot/handlers_pivot.go
@@ -23,9 +23,10 @@ package pivot
 import (
 	"encoding/json"
 	"io"
-	"log"
 	"net/http"
 	"time"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/account"
 	"github.com/CanonicalLtd/serial-vault/datastore"

--- a/service/pivot/handlers_pivot_user.go
+++ b/service/pivot/handlers_pivot_user.go
@@ -27,7 +27,7 @@ import (
 	"net/http"
 
 	"github.com/CanonicalLtd/serial-vault/service/assertion"
-	svlog "github.com/CanonicalLtd/serial-vault/service/log"
+	"github.com/CanonicalLtd/serial-vault/service/log"
 	"github.com/CanonicalLtd/serial-vault/service/request"
 	"github.com/CanonicalLtd/serial-vault/service/response"
 	"github.com/snapcore/snapd/asserts"
@@ -38,7 +38,7 @@ func SystemUserAssertion(w http.ResponseWriter, r *http.Request) response.ErrorR
 	// Check that we have an authorised API key header
 	_, err := request.CheckModelAPI(r)
 	if err != nil {
-		svlog.Message("PIVOTUSER", "invalid-api-key", "Invalid API key used")
+		log.Message("PIVOTUSER", "invalid-api-key", "Invalid API key used")
 		return response.ErrorInvalidAPIKey
 	}
 
@@ -72,7 +72,7 @@ func SystemUserAssertion(w http.ResponseWriter, r *http.Request) response.ErrorR
 	w.Header().Set("Content-Type", asserts.MediaType)
 	w.WriteHeader(http.StatusOK)
 	if _, err := fmt.Fprint(w, resp.Assertion); err != nil {
-		svlog.Message("PIVOTUSER", "system-user-assertion", err.Error())
+		log.Message("PIVOTUSER", "system-user-assertion", err.Error())
 	}
 
 	return response.ErrorResponse{Success: true}

--- a/service/response/response.go
+++ b/service/response/response.go
@@ -21,9 +21,10 @@ package response
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"net/http/httptest"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 )
 
 // JSONHeader is the JSON HTTP header

--- a/service/sign/handlers_sign.go
+++ b/service/sign/handlers_sign.go
@@ -25,9 +25,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"time"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	svlog "github.com/CanonicalLtd/serial-vault/service/log"

--- a/service/signinglog/actions.go
+++ b/service/signinglog/actions.go
@@ -21,8 +21,9 @@ package signinglog
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/service/auth"

--- a/service/store/handlers_store.go
+++ b/service/store/handlers_store.go
@@ -21,8 +21,9 @@ package store
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/service/auth"
 	"github.com/CanonicalLtd/serial-vault/service/response"

--- a/service/substore/actions.go
+++ b/service/substore/actions.go
@@ -22,8 +22,9 @@ package substore
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/service/auth"

--- a/service/testlog/actions.go
+++ b/service/testlog/actions.go
@@ -22,8 +22,9 @@ package testlog
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/service/auth"

--- a/service/testlog/handlers_testlog.go
+++ b/service/testlog/handlers_testlog.go
@@ -25,10 +25,11 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"strings"
 	"text/template"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/service/response"

--- a/service/user/actions.go
+++ b/service/user/actions.go
@@ -21,12 +21,11 @@ package user
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/service/auth"
-	svlog "github.com/CanonicalLtd/serial-vault/service/log"
+	"github.com/CanonicalLtd/serial-vault/service/log"
 	"github.com/CanonicalLtd/serial-vault/service/response"
 )
 
@@ -110,7 +109,7 @@ func createHandler(w http.ResponseWriter, authUser datastore.User, apiCall bool,
 
 	user.ID, err = datastore.Environ.DB.CreateUser(user)
 	if err != nil {
-		svlog.Error("error-creating-user", err)
+		log.Error("error-creating-user", err)
 		response.FormatStandardResponse(false, "error-creating-user", "", err.Error(), w)
 		return
 	}
@@ -125,7 +124,7 @@ func formatListResponse(users []datastore.User, w http.ResponseWriter) error {
 
 	// Encode the response as JSON
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		svlog.Error("error-user-response", err)
+		log.Error("error-user-response", err)
 		return err
 	}
 	return nil
@@ -136,7 +135,7 @@ func formatUserResponse(user datastore.User, w http.ResponseWriter) error {
 
 	// Encode the response as JSON
 	if err := json.NewEncoder(w).Encode(response); err != nil {
-		svlog.Error("error-user-response", err)
+		log.Error("error-user-response", err)
 		return err
 	}
 	return nil

--- a/service/user/handlers_users_test.go
+++ b/service/user/handlers_users_test.go
@@ -24,10 +24,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/config"
 	"github.com/CanonicalLtd/serial-vault/datastore"

--- a/store/store.go
+++ b/store/store.go
@@ -24,9 +24,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"time"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"gopkg.in/macaroon.v1"
 

--- a/usso/jwt.go
+++ b/usso/jwt.go
@@ -21,9 +21,10 @@ package usso
 
 import (
 	"errors"
-	"log"
 	"strings"
 	"time"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"net/http"
 

--- a/usso/openid.go
+++ b/usso/openid.go
@@ -21,10 +21,11 @@ package usso
 
 import (
 	"html/template"
-	"log"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/CanonicalLtd/serial-vault/service/log"
 
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/juju/usso"


### PR DESCRIPTION
* Changed configuration of the logger to the same configuration as we use in Talisker based services: ihttps://talisker.readthedocs.io/en/latest/logging.html#log-format
* Replaced all `log` with `github.com/CanonicalLtd/serial-vault/service/log`
* Implemented missing wrap methods to have a drop-in replacement of the library
* Fixed logging for the HTTP request
* Main change is in `service/log/log.go`

Example of the logging format
```
	InitLogger(logging.DEBUG)
        // Message is mapped to ERROR, formating is not the same as in Talisker, but it is closer as I can get with the current library 
	Message("MAIN", "foo-bar", "something is wrong")
	// 2019-06-17 16:12:00Z ERROR serialvault "something is wrong: method=MAIN, code=foo-bar"

        // Http request logging:
        // 2019-06-17 16:32:17Z INFO serialvault "GET /v1/authtoken 216ns"

        // Printf/Println is mapped to ERROR because in the code it used to log errors
	Println("Lorem Ipsum")
	// 2019-06-17 16:09:13Z ERROR serialvault "Lorem Ipsum"
	Printf(`I say: "%s %s" %d`, "Lorem", "Ipsum", 42)
	// 2019-06-17 16:09:13Z ERROR serialvault "I say: \"Lorem Ipsum\" 42"

	Debug("Lorem Ipsum")
	// 2019-06-17 16:09:13Z DEBUG serialvault "Lorem Ipsum"
	Debugf(`I say: "%s %s" %d`, "Lorem", "Ipsum", 42)
	// 2019-06-17 16:09:13Z DEBUG serialvault "I say: \"Lorem Ipsum\" 42"

	Info("Lorem Ipsum")
	// 2019-06-17 16:09:13Z INFO serialvault "Lorem Ipsum"
	Infof(`I say: "%s %s" %d`, "Lorem", "Ipsum", 42)
	// 2019-06-17 16:09:13Z INFO serialvault "I say: \"Lorem Ipsum\" 42"

	Warning("Lorem Ipsum")
	// 2019-06-17 16:09:13Z WARNING serialvault "Lorem Ipsum"
	Warningf(`I say: "%s %s" %d`, "Lorem", "Ipsum", 42)
	// 2019-06-17 16:09:13Z WARNING serialvault "I say: \"Lorem Ipsum\" 42"

	Error("Lorem Ipsum")
	// 2019-06-17 16:09:13Z ERROR serialvault "Lorem Ipsum"
	Errorf(`I say: "%s %s" %d`, "Lorem", "Ipsum", 42)
	// 2019-06-17 16:09:13Z ERROR serialvault "I say: \"Lorem Ipsum\" 42"

	Fatal("Lorem Ipsum")
	// 2019-06-17 16:09:03Z CRITICAL serialvault "Lorem Ipsum"

	Fatalf(`I say: "%s %s" %d`, "Lorem", "Ipsum", 42)
	// 2019-06-17 16:09:13Z CRITICAL serialvault "I say: \"Lorem Ipsum\" 42"
```