### PR TITLE
Fixed generated key registration in the store

### DIFF
--- a/datastore/keypairmanager.go
+++ b/datastore/keypairmanager.go
@@ -53,10 +53,9 @@ const listKeypairsForUserSQL = `
 const getKeypairSQL = "SELECT id, authority_id, key_id, active, sealed_key, assertion, key_name FROM keypair WHERE id=$1"
 const getKeypairByPublicIDSQL = "SELECT id, authority_id, key_id, active, sealed_key, assertion, key_name FROM keypair WHERE authority_id=$1 AND key_id=$2"
 const getKeypairByNameSQL = `
-	SELECT k.id, k.authority_id, k.key_id, k.active, k.sealed_key, k.assertion
-	FROM keypair k
-	INNER JOIN keypairstatus ks ON ks.keypair_id=k.id
-	WHERE k.authority_id=$1 AND ks.key_name=$2`
+	SELECT id, authority_id, key_id, active, sealed_key, assertion, key_name
+	FROM keypair
+	WHERE authority_id=$1 AND key_name=$2`
 const toggleKeypairSQL = "UPDATE keypair SET active=$2 WHERE id=$1"
 const toggleKeypairForUserSQL = `
 	UPDATE keypair k


### PR DESCRIPTION
This is a fix for https://github.com/CanonicalLtd/serial-vault/issues/234

As I can tell from the previous commits in this module, `keypairstatus` table is only used temporarily during key generation form the UI. After the key is generated the entry from `keypairstatus` is removed, this is why 
`getKeypairByNameSQL` query was not working.

As I can tell `key_name` was moved from `keypairstatus` to `keypair` so we don't need the JOIN on `keypairstatus` table anymore.

Tested manually on my local machine and the error is not appearing anymore. Not sure if key registration in the store is working, but particular this bug is fixed.
