### PR TITLE
Relax the serial vault email address regex

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Set the application version from a constant
-const version = "2.4-10"
+const version = "2.4-11"
 
 // Settings defines the parsed config file settings.
 type Settings struct {

--- a/datastore/useradapter.go
+++ b/datastore/useradapter.go
@@ -25,7 +25,7 @@ import (
 )
 
 const validUsernamePattern = defaultNicknamePattern
-const validEmailPattern = `^[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,4}$`
+const validEmailPattern = `^[_\.0-9a-zA-Z-+=]+@(([0-9a-zA-Z-]{1,}\.)*)[a-zA-Z]{2,}$`
 
 var validUsernameRegexp = regexp.MustCompile(validUsernamePattern)
 var validEmailRegexp = regexp.MustCompile(validEmailPattern)

--- a/datastore/useradapter_test.go
+++ b/datastore/useradapter_test.go
@@ -117,11 +117,8 @@ func TestUserEmailWithoutAt(t *testing.T) {
 func TestUserEmailWithoutDot(t *testing.T) {
 	email := "my@mailcom"
 	err := validateUserEmail(email)
-	if err == nil {
-		t.Error("Expected email not to be valid, but it is")
-	}
-	if !strings.Contains(err.Error(), "Email contains invalid characters") {
-		t.Error("Error happening is not the one searched for")
+	if err != nil {
+		t.Error("Expected email to be valid, but it is not")
 	}
 }
 
@@ -144,6 +141,7 @@ func TestValidEmails(t *testing.T) {
 		"example-indeed@strange-example.com",
 		"example@s.example",
 		"foo=bar@a-b-c.super",
+		"admin@localhost",
 	}
 	for _, email := range data {
 		err := validateUserEmail(email)

--- a/datastore/useradapter_test.go
+++ b/datastore/useradapter_test.go
@@ -128,10 +128,27 @@ func TestUserEmailWithoutDot(t *testing.T) {
 func TestUserEmailWithLargeDomain(t *testing.T) {
 	email := "my@mail.domain"
 	err := validateUserEmail(email)
-	if err == nil {
-		t.Error("Expected email not to be valid, but it is")
+	if err != nil {
+		t.Error("Expected email to be valid, but it is not")
 	}
-	if !strings.Contains(err.Error(), "Email contains invalid characters") {
-		t.Error("Error happening is not the one searched for")
+}
+
+func TestValidEmails(t *testing.T) {
+	data := []string{
+		"very.common@example.com",
+		"disposable.style.email.with+symbol@example.com",
+		"other.email-with-hyphen@example.com",
+		"fully-qualified-domain@example.com",
+		"user.name+tag+sorting@example.com",
+		"x@example.com",
+		"example-indeed@strange-example.com",
+		"example@s.example",
+		"foo=bar@a-b-c.super",
+	}
+	for _, email := range data {
+		err := validateUserEmail(email)
+		if err != nil {
+			t.Errorf("Expected email [%s] to be valid, but it is not", email)
+		}
 	}
 }


### PR DESCRIPTION
Current regex blocks modern gTLDs like `@canvas.build`