### PR TITLE
Return correct error message UpsertModelAssert function

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Set the application version from a constant
-const version = "2.4-13"
+const version = "2.4-14"
 
 // Settings defines the parsed config file settings.
 type Settings struct {

--- a/datastore/modelassertmanager.go
+++ b/datastore/modelassertmanager.go
@@ -144,8 +144,7 @@ func (db *DB) UpsertModelAssert(m ModelAssertion) error {
 		_, err = db.CreateModelAssert(m)
 	}
 
-	return fmt.Errorf("error upserting the model assertion for model %d: %v", m.ModelID, err)
-
+	return err
 }
 
 // deleteModelAssert deletes the model assertion details


### PR DESCRIPTION
The problem was: if you create a new model and hit "Configure the model assertion headers" to create or edit an assertion for this model, you will always get an error message: "Error creating the assertion: error upserting the model assertion for model 26: <nil>" even if all was good