### PR TITLE
Fixed permissions so an admin users can't create an account anymore

### DIFF
--- a/service/account/actions.go
+++ b/service/account/actions.go
@@ -75,7 +75,7 @@ func listHandler(w http.ResponseWriter, user datastore.User, apiCall bool) {
 func createHandler(w http.ResponseWriter, user datastore.User, apiCall bool, acct datastore.Account) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 
-	err := auth.CheckUserPermissions(user, datastore.Admin, apiCall)
+	err := auth.CheckUserPermissions(user, datastore.Superuser, apiCall)
 	if err != nil {
 		response.FormatStandardResponse(false, "error-auth", "", "", w)
 		return
@@ -96,7 +96,7 @@ func createHandler(w http.ResponseWriter, user datastore.User, apiCall bool, acc
 func getHandler(w http.ResponseWriter, user datastore.User, apiCall bool, accountID int) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 
-	err := auth.CheckUserPermissions(user, datastore.Admin, apiCall)
+	err := auth.CheckUserPermissions(user, datastore.Superuser, apiCall)
 	if err != nil {
 		response.FormatStandardResponse(false, "error-auth", "", "", w)
 		return
@@ -116,7 +116,7 @@ func getHandler(w http.ResponseWriter, user datastore.User, apiCall bool, accoun
 func updateHandler(w http.ResponseWriter, user datastore.User, apiCall bool, acct datastore.Account) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 
-	err := auth.CheckUserPermissions(user, datastore.Admin, apiCall)
+	err := auth.CheckUserPermissions(user, datastore.Superuser, apiCall)
 	if err != nil {
 		response.FormatStandardResponse(false, "error-auth", "", "", w)
 		return
@@ -137,8 +137,9 @@ func updateHandler(w http.ResponseWriter, user datastore.User, apiCall bool, acc
 func uploadHandler(w http.ResponseWriter, user datastore.User, apiCall bool, assertionRequest AssertionRequest) {
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 
-	err := auth.CheckUserPermissions(user, datastore.Admin, apiCall)
+	err := auth.CheckUserPermissions(user, datastore.Superuser, apiCall)
 	if err != nil {
+		log.Println("Error checking user permissions:", err)
 		response.FormatStandardResponse(false, "error-auth", "", "", w)
 		return
 	}

--- a/service/account/handlers_accounts_test.go
+++ b/service/account/handlers_accounts_test.go
@@ -153,25 +153,31 @@ func (s *AccountSuite) TestCreateGetUpdateAccountHandlers(c *check.C) {
 
 	account := datastore.Account{ID: 2, AuthorityID: "vendor", ResellerAPI: false}
 	acc, _ := json.Marshal(account)
+	accBrokenJSON := []byte(`{"user"`)
 
 	tests := []AccountTest{
-		{"POST", "/v1/accounts", nil, 400, "application/json; charset=UTF-8", 0, false, false, false, false, 0},
-		{"POST", "/v1/accounts", acc, 200, "application/json; charset=UTF-8", 0, false, true, false, false, 0},
-		{"POST", "/v1/accounts", acc, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, false, false, 1},
-		{"POST", "/v1/accounts", acc, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, true, false, 1},
-		{"POST", "/v1/accounts", acc, 400, "application/json; charset=UTF-8", 0, true, false, false, false, 0},
+		{"POST", "/v1/accounts", accBrokenJSON, 400, "application/json; charset=UTF-8", datastore.Superuser, false, false, false, false, 0},
+		{"POST", "/v1/accounts", nil, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
+		{"POST", "/v1/accounts", acc, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
+		{"POST", "/v1/accounts", acc, 400, "application/json; charset=UTF-8", datastore.Admin, false, false, false, false, 0},
+		{"POST", "/v1/accounts", acc, 200, "application/json; charset=UTF-8", datastore.Superuser, true, true, false, false, 1},
+		{"POST", "/v1/accounts", acc, 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, true, false, 1},
+		{"POST", "/v1/accounts", acc, 400, "application/json; charset=UTF-8", datastore.Invalid, true, false, false, false, 0},
 
-		{"GET", "/v1/accounts/99999", nil, 400, "application/json; charset=UTF-8", 0, false, false, false, false, 0},
-		{"GET", "/v1/accounts/1", nil, 200, "application/json; charset=UTF-8", 0, false, true, false, false, 0},
-		{"GET", "/v1/accounts/1", nil, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, false, false, 0},
-		{"GET", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, true, false, 0},
-		{"GET", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", 0, true, false, false, false, 0},
+		{"GET", "/v1/accounts/99999", nil, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
+		{"GET", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
+		{"GET", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", datastore.Admin, false, false, false, false, 0},
+		{"GET", "/v1/accounts/1", nil, 200, "application/json; charset=UTF-8", datastore.Superuser, true, true, false, false, 0},
+		{"GET", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, true, false, 0},
+		{"GET", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", datastore.Invalid, true, false, false, false, 0},
 
-		{"PUT", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", 0, false, false, false, false, 0},
-		{"PUT", "/v1/accounts/1", acc, 200, "application/json; charset=UTF-8", 0, false, true, false, false, 0},
-		{"PUT", "/v1/accounts/1", acc, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, false, false, 0},
-		{"PUT", "/v1/accounts/1", acc, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, true, false, 0},
-		{"PUT", "/v1/accounts/1", acc, 400, "application/json; charset=UTF-8", 0, true, false, false, false, 0},
+		{"PUT", "/v1/accounts/1", accBrokenJSON, 400, "application/json; charset=UTF-8", datastore.Superuser, false, false, false, false, 0},
+		{"PUT", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
+		{"PUT", "/v1/accounts/1", acc, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
+		{"PUT", "/v1/accounts/1", acc, 400, "application/json; charset=UTF-8", datastore.Admin, false, false, false, false, 0},
+		{"PUT", "/v1/accounts/1", acc, 200, "application/json; charset=UTF-8", datastore.Superuser, true, true, false, false, 0},
+		{"PUT", "/v1/accounts/1", acc, 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, true, false, 0},
+		{"PUT", "/v1/accounts/1", acc, 400, "application/json; charset=UTF-8", datastore.Invalid, true, false, false, false, 0},
 	}
 
 	for _, t := range tests {
@@ -228,16 +234,19 @@ func (s *AccountSuite) TestAccountsUploadHandler(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	tests := []AccountTest{
-		{"POST", "/v1/accounts/upload", request, 200, "application/json; charset=UTF-8", 0, false, true, false, false, 0},
-		{"POST", "/v1/accounts/upload", request, 200, "application/json; charset=UTF-8", datastore.Admin, true, true, false, false, 0},
+		{"POST", "/v1/accounts/upload", nil, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
+		{"POST", "/v1/accounts/upload", request, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
+		{"POST", "/v1/accounts/upload", request, 200, "application/json; charset=UTF-8", datastore.Superuser, true, true, false, false, 0},
 		{"POST", "/v1/accounts/upload", request, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, true, false, 0},
-		{"POST", "/v1/accounts/upload", request, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, true, false, 0},
+		{"POST", "/v1/accounts/upload", request, 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, true, false, 0},
+		{"POST", "/v1/accounts/upload", request, 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, true, false, 0},
+		{"POST", "/v1/accounts/upload", request, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, false, false, 0},
 		{"POST", "/v1/accounts/upload", request, 400, "application/json; charset=UTF-8", datastore.Standard, true, false, false, false, 0},
-		{"POST", "/v1/accounts/upload", []byte("InvalidData"), 400, "application/json; charset=UTF-8", datastore.Admin, true, false, false, false, 0},
-		{"POST", "/v1/accounts/upload", invalidRequest1, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, false, false, 0},
-		{"POST", "/v1/accounts/upload", invalidRequest2, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, false, false, 0},
-		{"POST", "/v1/accounts/upload", invalidRequest3, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, false, false, 0},
-		{"POST", "/v1/accounts/upload", request, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, false, true, 0},
+		{"POST", "/v1/accounts/upload", []byte("InvalidData"), 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, false, false, 0},
+		{"POST", "/v1/accounts/upload", invalidRequest1, 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, false, false, 0},
+		{"POST", "/v1/accounts/upload", invalidRequest2, 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, false, false, 0},
+		{"POST", "/v1/accounts/upload", invalidRequest3, 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, false, false, 0},
+		{"POST", "/v1/accounts/upload", request, 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, false, true, 0},
 	}
 
 	for _, t := range tests {

--- a/service/account/handlers_accounts_test.go
+++ b/service/account/handlers_accounts_test.go
@@ -153,31 +153,28 @@ func (s *AccountSuite) TestCreateGetUpdateAccountHandlers(c *check.C) {
 
 	account := datastore.Account{ID: 2, AuthorityID: "vendor", ResellerAPI: false}
 	acc, _ := json.Marshal(account)
-	accBrokenJSON := []byte(`{"user"`)
 
 	tests := []AccountTest{
-		{"POST", "/v1/accounts", accBrokenJSON, 400, "application/json; charset=UTF-8", datastore.Superuser, false, false, false, false, 0},
-		{"POST", "/v1/accounts", nil, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
-		{"POST", "/v1/accounts", acc, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
+		{"POST", "/v1/accounts", nil, 400, "application/json; charset=UTF-8", 0, false, false, false, false, 0},
+		{"POST", "/v1/accounts", acc, 400, "application/json; charset=UTF-8", 0, false, false, false, false, 0},
 		{"POST", "/v1/accounts", acc, 400, "application/json; charset=UTF-8", datastore.Admin, false, false, false, false, 0},
 		{"POST", "/v1/accounts", acc, 200, "application/json; charset=UTF-8", datastore.Superuser, true, true, false, false, 1},
 		{"POST", "/v1/accounts", acc, 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, true, false, 1},
-		{"POST", "/v1/accounts", acc, 400, "application/json; charset=UTF-8", datastore.Invalid, true, false, false, false, 0},
+		{"POST", "/v1/accounts", acc, 400, "application/json; charset=UTF-8", 0, true, false, false, false, 0},
 
-		{"GET", "/v1/accounts/99999", nil, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
-		{"GET", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
+		{"GET", "/v1/accounts/99999", nil, 400, "application/json; charset=UTF-8", 0, false, false, false, false, 0},
+		{"GET", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", 0, false, false, false, false, 0},
 		{"GET", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", datastore.Admin, false, false, false, false, 0},
 		{"GET", "/v1/accounts/1", nil, 200, "application/json; charset=UTF-8", datastore.Superuser, true, true, false, false, 0},
 		{"GET", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, true, false, 0},
-		{"GET", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", datastore.Invalid, true, false, false, false, 0},
+		{"GET", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", 0, true, false, false, false, 0},
 
-		{"PUT", "/v1/accounts/1", accBrokenJSON, 400, "application/json; charset=UTF-8", datastore.Superuser, false, false, false, false, 0},
-		{"PUT", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
-		{"PUT", "/v1/accounts/1", acc, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
+		{"PUT", "/v1/accounts/1", nil, 400, "application/json; charset=UTF-8", 0, false, false, false, false, 0},
+		{"PUT", "/v1/accounts/1", acc, 400, "application/json; charset=UTF-8", 0, false, false, false, false, 0},
 		{"PUT", "/v1/accounts/1", acc, 400, "application/json; charset=UTF-8", datastore.Admin, false, false, false, false, 0},
 		{"PUT", "/v1/accounts/1", acc, 200, "application/json; charset=UTF-8", datastore.Superuser, true, true, false, false, 0},
 		{"PUT", "/v1/accounts/1", acc, 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, true, false, 0},
-		{"PUT", "/v1/accounts/1", acc, 400, "application/json; charset=UTF-8", datastore.Invalid, true, false, false, false, 0},
+		{"PUT", "/v1/accounts/1", acc, 400, "application/json; charset=UTF-8", 0, true, false, false, false, 0},
 	}
 
 	for _, t := range tests {
@@ -234,8 +231,8 @@ func (s *AccountSuite) TestAccountsUploadHandler(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	tests := []AccountTest{
-		{"POST", "/v1/accounts/upload", nil, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
-		{"POST", "/v1/accounts/upload", request, 400, "application/json; charset=UTF-8", datastore.Invalid, false, false, false, false, 0},
+		{"POST", "/v1/accounts/upload", nil, 400, "application/json; charset=UTF-8", 0, false, false, false, false, 0},
+		{"POST", "/v1/accounts/upload", request, 400, "application/json; charset=UTF-8", 0, false, false, false, false, 0},
 		{"POST", "/v1/accounts/upload", request, 200, "application/json; charset=UTF-8", datastore.Superuser, true, true, false, false, 0},
 		{"POST", "/v1/accounts/upload", request, 400, "application/json; charset=UTF-8", datastore.Admin, true, false, true, false, 0},
 		{"POST", "/v1/accounts/upload", request, 400, "application/json; charset=UTF-8", datastore.Superuser, true, false, true, false, 0},

--- a/webapp-admin/package.json
+++ b/webapp-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp-admin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "dependencies": {
     "history": "^4.10.1",

--- a/webapp-admin/src/__tests__/accountform-test.js
+++ b/webapp-admin/src/__tests__/accountform-test.js
@@ -26,15 +26,16 @@ configure({ adapter: new Adapter() });
 // Mock the AppState method for locale
 window.AppState = {getLocale: function() {return 'en'}};
 
-const token = { role: 200 }
-const tokenUser = { role: 100 }
+const tokenSuperAdmin = { role: 300 }
+const tokenAdmin      = { role: 200 }
+const tokenUser       = { role: 100 }
 
 describe('account form', function() {
     it('displays the new account form', function() {
 
         // Render the component
         const component = shallow(
-            <AccountForm token={token} />
+            <AccountForm token={tokenSuperAdmin} />
         );
 
         expect(component.find('section')).toHaveLength(1)
@@ -52,11 +53,21 @@ describe('account form', function() {
         expect(component.find('AlertBox')).toHaveLength(1)
     })
 
-    it('displays error with insufficient permissions', function() {
+    it('displays error with insufficient permissions for user', function() {
 
         // Render the component
         const component = shallow(
             <AccountForm token={tokenUser} />
+        );
+
+        expect(component.find('div')).toHaveLength(1)
+        expect(component.find('AlertBox')).toHaveLength(1)
+    })
+
+    it('displays error with insufficient permissions for admin', function() {
+        // Render the component
+        const component = shallow(
+            <AccountForm token={tokenAdmin} />
         );
 
         expect(component.find('div')).toHaveLength(1)

--- a/webapp-admin/src/__tests__/accountkeyform-test.js
+++ b/webapp-admin/src/__tests__/accountkeyform-test.js
@@ -26,15 +26,16 @@ configure({ adapter: new Adapter() });
 // Mock the AppState method for locale
 window.AppState = {getLocale: function() {return 'en'}};
 
-const token = { role: 200 }
-const tokenUser = { role: 100 }
+const tokenSuperAdmin = { role: 300 }
+const tokenAdmin      = { role: 200 }
+const tokenUser       = { role: 100 }
 
 describe('account key form', function() {
     it('displays the new account key form', function() {
 
         // Render the component
         const component = shallow(
-            <AccountKeyForm token={token} />
+            <AccountKeyForm token={tokenSuperAdmin} />
         );
 
         expect(component.find('section')).toHaveLength(1)
@@ -52,11 +53,21 @@ describe('account key form', function() {
         expect(component.find('AlertBox')).toHaveLength(1)
     })
 
-    it('displays error with insufficient permissions', function() {
+    it('displays error with insufficient permissions for user', function() {
 
         // Render the component
         const component = shallow(
             <AccountKeyForm token={tokenUser} />
+        );
+
+        expect(component.find('div')).toHaveLength(1)
+        expect(component.find('AlertBox')).toHaveLength(1)
+    })
+
+    it('displays error with insufficient permissions for admin', function() {
+        // Render the component
+        const component = shallow(
+            <AccountKeyForm token={tokenAdmin} />
         );
 
         expect(component.find('div')).toHaveLength(1)

--- a/webapp-admin/src/__tests__/accountlist-test.js
+++ b/webapp-admin/src/__tests__/accountlist-test.js
@@ -35,8 +35,9 @@ const KEYPAIRS_INCOMPLETE = [{ID: 1, AuthorityID: "canonical", KeyID: "123", Ass
 const MODELS = [{id: 1, "authority-id-user": "canonical", "key-id-user": "123"}]
 const MODELS_NOTUSED = [{id: 1, "authority-id-user": "canonical", "key-id-user": "456"}]
 
-const token = { role: 200 }
-const tokenUser = { role: 100 }
+const tokenSuperAdmin = { role: 300 }
+const tokenAdmin      = { role: 200 }
+const tokenUser       = { role: 100 }
 
 describe('accounts list', function() {
 
@@ -44,7 +45,7 @@ describe('accounts list', function() {
 
         // Render the component
         const component = shallow(
-            <AccountList token={token} selectedAccount={{}} keypairs={{}} />
+            <AccountList token={tokenSuperAdmin} selectedAccount={{}} keypairs={{}} />
         );
 
         expect(component.find('section')).toHaveLength(2)
@@ -56,7 +57,7 @@ describe('accounts list', function() {
 
         // Render the component
         const component = shallow(
-            <AccountList selectedAccount={{}} keypairs={KEYPAIRS} models={MODELS} token={token} />
+            <AccountList selectedAccount={{}} keypairs={KEYPAIRS} models={MODELS} token={tokenSuperAdmin} />
         );
 
         expect(component.find('section')).toHaveLength(2)
@@ -70,7 +71,7 @@ describe('accounts list', function() {
 
         // Render the component
         const component = shallow(
-            <AccountList selectedAccount={account} keypairs={KEYPAIRS} models={MODELS} token={token} />
+            <AccountList selectedAccount={account} keypairs={KEYPAIRS} models={MODELS} token={tokenSuperAdmin} />
         );
 
         expect(component.find('section')).toHaveLength(2)
@@ -86,7 +87,7 @@ describe('accounts list', function() {
 
         // Render the component
         const component = shallow(
-            <AccountList selectedAccount={ACCOUNTS} keypairs={KEYPAIRS} models={MODELS_NOTUSED} token={token} />
+            <AccountList selectedAccount={ACCOUNTS} keypairs={KEYPAIRS} models={MODELS_NOTUSED} token={tokenSuperAdmin} />
         );
 
         expect(component.find('section')).toHaveLength(2)
@@ -101,7 +102,7 @@ describe('accounts list', function() {
 
         // Render the component
         const component = shallow(
-            <AccountList selectedAccount={ACCOUNTS} keypairs={KEYPAIRS_INCOMPLETE} models={MODELS} token={token} />
+            <AccountList selectedAccount={ACCOUNTS} keypairs={KEYPAIRS_INCOMPLETE} models={MODELS} token={tokenSuperAdmin} />
         );
 
         expect(component.find('section')).toHaveLength(2)
@@ -115,7 +116,7 @@ describe('accounts list', function() {
 
         // Render the component
         const component = shallow(
-            <AccountList selectedAccount={{}} keypairs={KEYPAIRS_INCOMPLETE} models={MODELS} token={token} />
+            <AccountList selectedAccount={{}} keypairs={KEYPAIRS_INCOMPLETE} models={MODELS} token={tokenSuperAdmin} />
         );
 
         expect(component.find('section')).toHaveLength(2)
@@ -136,11 +137,21 @@ describe('accounts list', function() {
         expect(component.find('AlertBox')).toHaveLength(1)
     })
 
-    it('displays error with insufficient permissions', function() {
+    it('displays error with insufficient permissions for user', function() {
 
         // Render the component
         const component = shallow(
             <AccountList token={tokenUser} />
+        );
+
+        expect(component.find('div')).toHaveLength(1)
+        expect(component.find('AlertBox')).toHaveLength(1)
+    })
+
+    it('displays error with insufficient permissions for admin', function() {
+        // Render the component
+        const component = shallow(
+            <AccountList token={tokenAdmin} />
         );
 
         expect(component.find('div')).toHaveLength(1)

--- a/webapp-admin/src/__tests__/navigation-test.js
+++ b/webapp-admin/src/__tests__/navigation-test.js
@@ -77,7 +77,7 @@ describe('navigation', function() {
     // Check all the expected elements are rendered
     var ul = ReactTestUtils.findRenderedDOMComponentWithTag(page, 'ul');
     // 4 links and account menu
-    expect(ul.children.length).toBe(5);
+    expect(ul.children.length).toBe(4);
   });
 
   it('displays the navigation menu with models active', function() {
@@ -91,13 +91,10 @@ describe('navigation', function() {
 
     // Check all the expected elements are rendered
     var ul = ReactTestUtils.findRenderedDOMComponentWithTag(page, 'ul');
-    expect(ul.children.length).toBe(5);
-    expect(ul.children[1].firstChild.textContent).toBe('Accounts');
-    expect(ul.children[1].firstChild.className).toBe('');
-    expect(ul.children[1].firstChild.className).toBe('');
-    expect(ul.children[2].firstChild.textContent).toBe('Signing Keys');
-    expect(ul.children[3].firstChild.textContent).toBe('Models');
-    expect(ul.children[4].firstChild.textContent).toBe('Signing Log');
+    expect(ul.children.length).toBe(4);
+    expect(ul.children[1].firstChild.textContent).toBe('Signing Keys');
+    expect(ul.children[2].firstChild.textContent).toBe('Models');
+    expect(ul.children[3].firstChild.textContent).toBe('Signing Log');
   });
 
   it('displays the OpenID link when user auth is enabled', function() {

--- a/webapp-admin/src/components/AccountEdit.js
+++ b/webapp-admin/src/components/AccountEdit.js
@@ -17,7 +17,7 @@
 import React, {Component} from 'react'
 import  AlertBox from './AlertBox'
 import Accounts from '../models/accounts'
-import {T, parseResponse, formatError, isUserAdmin} from './Utils';
+import {T, parseResponse, formatError, isUserSuperuser} from './Utils';
 
 class AccountEdit extends Component {
 
@@ -37,7 +37,7 @@ class AccountEdit extends Component {
     getAccount(accountId) {
         Accounts.get(accountId).then((response) => {
             var data = JSON.parse(response.body);
-
+            
             if (response.statusCode >= 300) {
                 this.setState({error: this.formatError(data), hideForm: true});
             } else {
@@ -83,7 +83,7 @@ class AccountEdit extends Component {
     }
 
     render() {
-        if (!isUserAdmin(this.props.token)) {
+        if (!isUserSuperuser(this.props.token)) {
             return (
                 <div className="row">
                 <AlertBox message={T('error-no-permissions')} />

--- a/webapp-admin/src/components/AccountEdit.js
+++ b/webapp-admin/src/components/AccountEdit.js
@@ -37,7 +37,6 @@ class AccountEdit extends Component {
     getAccount(accountId) {
         Accounts.get(accountId).then((response) => {
             var data = JSON.parse(response.body);
-            
             if (response.statusCode >= 300) {
                 this.setState({error: this.formatError(data), hideForm: true});
             } else {

--- a/webapp-admin/src/components/AccountForm.js
+++ b/webapp-admin/src/components/AccountForm.js
@@ -17,7 +17,7 @@
 import React, {Component} from 'react'
 import  AlertBox from './AlertBox'
 import Accounts from '../models/accounts'
-import {T, parseResponse, formatError, isUserAdmin} from './Utils';
+import {T, parseResponse, formatError, isUserSuperuser} from './Utils';
 
 class AccountForm extends Component {
 
@@ -57,7 +57,7 @@ class AccountForm extends Component {
     }
 
     render() {
-        if (!isUserAdmin(this.props.token)) {
+        if (!isUserSuperuser(this.props.token)) {
             return (
                 <div className="row">
                 <AlertBox message={T('error-no-permissions')} />

--- a/webapp-admin/src/components/AccountKeyForm.js
+++ b/webapp-admin/src/components/AccountKeyForm.js
@@ -17,7 +17,7 @@
 import React, {Component} from 'react'
 import  AlertBox from './AlertBox'
 import Keypairs from '../models/keypairs'
-import {T, parseResponse, formatError, isUserAdmin} from './Utils';
+import {T, parseResponse, formatError, isUserSuperuser} from './Utils';
 
 class AccountKeyForm extends Component {
 
@@ -77,8 +77,7 @@ class AccountKeyForm extends Component {
     }
 
     render() {
-
-        if (!isUserAdmin(this.props.token)) {
+        if (!isUserSuperuser(this.props.token)) {
             return (
                 <div className="row">
                 <AlertBox message={T('error-no-permissions')} />

--- a/webapp-admin/src/components/AccountList.js
+++ b/webapp-admin/src/components/AccountList.js
@@ -17,7 +17,7 @@
 import React, {Component} from 'react'
 import Models from '../models/models'
 import AlertBox from './AlertBox'
-import {T, isUserAdmin} from './Utils'
+import {T, isUserSuperuser} from './Utils'
 
 class AccountList extends Component {
 
@@ -92,12 +92,20 @@ class AccountList extends Component {
     }
 
     renderAccounts() {
+        if (!isUserSuperuser(this.props.token)) {
+            return (
+                <div className="row">
+                <AlertBox message={T('error-no-permissions')} />
+                </div>
+            )
+        }
+
         if (this.getAccounts().length > 0) {
             return (
                 <table>
                 <thead>
                     <tr>
-                        {isUserAdmin(this.props.token) ? <th className="small"></th> : ''}
+                        {isUserSuperuser(this.props.token) ? <th className="small"></th> : ''}
                         <th>{T('account')}</th><th>{T('assertion-status')}</th><th className="small">{T('reseller')}</th>
                     </tr>
                 </thead>
@@ -105,7 +113,7 @@ class AccountList extends Component {
                     {this.getAccounts().map((acc) => {
                     return (
                         <tr key={acc.ID}>
-                            {isUserAdmin(this.props.token) ? 
+                            {isUserSuperuser(this.props.token) ? 
                                 <td>
                                     <div>
                                     <a href={'/accounts/account/' + acc.ID} className="p-button--brand small" title={T('edit-account')}><i className="fa fa-pencil"></i></a>
@@ -165,7 +173,7 @@ class AccountList extends Component {
     }
 
     render() {
-        if (!isUserAdmin(this.props.token)) {
+        if (!isUserSuperuser(this.props.token)) {
             return (
                 <div className="row">
                 <AlertBox message={T('error-no-permissions')} />

--- a/webapp-admin/src/components/ModelAssertion.js
+++ b/webapp-admin/src/components/ModelAssertion.js
@@ -152,7 +152,6 @@ class ModelAssertion extends Component {
 
         Models.assertion(this.state.assertion).then((response) => {
             var data = JSON.parse(response.body);
-            console.log(data)
             if (response.statusCode >= 300) {
                 this.setState({error: formatError(data)});
             } else {

--- a/webapp-admin/src/components/Navigation.js
+++ b/webapp-admin/src/components/Navigation.js
@@ -20,7 +20,7 @@ import {T, isLoggedIn} from './Utils'
 import {Role} from './Constants'
 
 const linksSuperuser = ['accounts', 'signing-keys', 'models', 'signinglog', "users"];
-const linksAdmin = ['accounts', 'signing-keys', 'models', 'signinglog'];
+const linksAdmin = ['signing-keys', 'models', 'signinglog'];
 const linksStandard = ['systemuser'];
 
 


### PR DESCRIPTION
Only users with SuperAdmin rights are allowed to create new accounts. This means that the `Account` tab in the admin UI is not visible to all other users anymore (same logic as for the `User` tab).