### PR TITLE
Clean up the previews frontend build before create a new one

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,6 +17,8 @@ jobs:
         cd webapp-admin
         npm install
         npm run build
+        rm ../static/js/*
+        rm ../static/css/*
         cp -R build/static/js ../static
         cp -R build/static/css ../static
         cp -R build/index.html ../static/app.html

--- a/webapp-admin/package.json
+++ b/webapp-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webapp-admin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "dependencies": {
     "history": "^4.10.1",


### PR DESCRIPTION
 `npm run build`  creates unique css/js files with hashes as part of the filename. Because of this, we need the remove all css/js files from the previews build