### PR TITLE
Check for updates to GitHub Actions every weekday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"


### PR DESCRIPTION
This enables dependabot to send PRs when the GitHub actions using this repo require updates.

https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-github-dependabot