### PR TITLE
Added ols-vms config and additional Makefile target to build tarball

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ on:
     branches: master
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js 12.x

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,7 @@ TAR_BASE_NAME = ${SERVICE_NAME}-v${VERSION}.tar
 TGZ_NAME = ${TMP}/${SERVICE_NAME}-payload-${VERSION}.tgz
 SWIFT_CONTAINER_NAME = ${SERVICE_NAME}.canonical.com
 
-# golang is installed from the snap
-GO ?= /snap/bin/go
+GO ?= go
 
 # this repo contains external dependencies for an internal build
 VENDOR_BRANCH_URL ?= lp:~ubuntuone-pqm-team/serial-vault/+git/dependencies

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,12 @@ GOTAGS=-tags netgo
 
 SERVICE_NAME=serial-vault
 LOCAL_SERVICE_NAME = ${GOBIN}/${SERVICE_NAME}
-GO ?= go
+TAR_BASE_NAME = ${SERVICE_NAME}-v${VERSION}.tar
+TGZ_NAME = ${TMP}/${SERVICE_NAME}-payload-${VERSION}.tgz
+SWIFT_CONTAINER_NAME = ${SERVICE_NAME}.canonical.com
+
+# golang is installed from the snap
+GO ?= /snap/bin/go
 
 # this repo contains external dependencies for an internal build
 VENDOR_BRANCH_URL ?= lp:~ubuntuone-pqm-team/serial-vault/+git/dependencies
@@ -110,6 +115,27 @@ static-test:
 
 .PHONY: test
 test: unit-test static-test
+
+.PHONY: build-tarball
+build-tarball: install
+	$(info # Creating tarball ${TGZ_NAME} with binaries and assets...)
+	# cd ${TMP}
+	# create tar file with  assets in 'static' folder
+	tar -cvf ${TAR_BASE_NAME} static
+	# update tar file with serial-vault and serial-vault-admin built binaries
+	tar -uvf ${TAR_BASE_NAME} -C ${GOBIN} serial-vault serial-vault-admin
+	# compress with gzip
+	gzip -9 ${TAR_BASE_NAME}
+	# rename tgz file including the release 
+	mv ${TAR_BASE_NAME}.gz ${TGZ_NAME}
+	# calculate md5sum and create file with its value
+	md5sum ${TGZ_NAME} > ${TGZ_NAME}.md5
+
+.PHONY: publish-tarball
+publish-tarball: build-tarball
+	[ ! -e ~/.config/swift/serial-vault ] || . ~/.config/swift/serial-vault; \
+	./publish-to-swift --debug $(SWIFT_CONTAINER_NAME) $(TAR_BASE_NAME) $(TGZ_NAME) serial-vault=$(VERSION)
+	./publish-to-swift --debug $(SWIFT_CONTAINER_NAME) $(TAR_BASE_NAME).md5 ${TGZ_NAME}.md5 serial-vault=$(VERSION)
 
 # only for dev/testing, don't commit output of this command by yourself
 # it will be done automatically by CI 

--- a/dependencies-devel.txt
+++ b/dependencies-devel.txt
@@ -1,3 +1,2 @@
 build-essential
 git
-golang-go

--- a/ols-vms.conf
+++ b/ols-vms.conf
@@ -1,0 +1,16 @@
+[serial-vault]
+
+vm.class = lxd
+vm.architecture = amd64
+# Must be xenial because the thing is deployed on xenial and we live in the past.
+vm.release = xenial
+vm.update = True
+vm.packages = python3-swiftclient, @dependencies.txt, @dependencies-devel.txt
+jenkaas.secrets = swift/serial-vault:.config/swift/serial-vault
+
+# sideload snaps
+vm.setup_scripts = /var/lib/jenkins/jenkaas/scripts/snap-sideload.sh
+# go 1.13.15 from Michael Hudson-Doyle (mwhudson)
+sideload.classic_snaps = go_6264
+sideload.snaps = core18_1705 snapd_7264
+sideload.snaps.url = https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_2d567acde3684dc4b50675355c334532/ols-sideloader

--- a/publish-to-swift
+++ b/publish-to-swift
@@ -1,0 +1,133 @@
+#! /usr/bin/python3
+
+"""Publish a built tarball to Swift for deployment."""
+
+from argparse import ArgumentParser
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+
+def ensure_container_privs(container_name):
+    """Ensure that the container exists and is world-readable.
+
+    This allows us to give services suitable credentials for getting the
+    built code from a container.
+    """
+    subprocess.run(["swift", "post", container_name, "--read-acl", ".r:*"])
+
+
+def get_swift_storage_url():
+    # This is a bit cumbersome, but probably still easier than bothering
+    # with swiftclient.
+    auth = subprocess.run(
+        ["swift", "auth"],
+        stdout=subprocess.PIPE, check=True,
+        universal_newlines=True).stdout.splitlines()
+    return [
+        line.split("=", 1)[1] for line in auth
+        if line.startswith("export OS_STORAGE_URL=")][0]
+
+
+def publish_file_to_swift(container_name, object_path, local_path,
+                          overwrite=True):
+    """Publish a file to a Swift container."""
+    storage_url = get_swift_storage_url()
+
+    already_published = False
+    # Some swift versions unhelpfully exit 0 regardless of whether the
+    # object exists.
+    try:
+        stats = subprocess.run(
+            ["swift", "stat", container_name, object_path],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=True,
+            universal_newlines=True).stdout
+        if re.search(
+                r"Object: %s$" % re.escape(object_path), stats, flags=re.M):
+            already_published = True
+    except subprocess.CalledProcessError:
+        pass
+
+    if already_published:
+        print("Object {} already published to {}.".format(
+            object_path, container_name))
+        if not overwrite:
+            return
+
+    print("Publishing {} to {} as {}.".format(
+        local_path, container_name, object_path))
+    try:
+        subprocess.run(
+            ["swift", "upload", "--object-name", object_path,
+             container_name, local_path])
+    except subprocess.CalledProcessError:
+        sys.exit("Failed to upload {} to {} as {}".format(
+            local_path, container_name, object_path))
+
+    print("Published file: {}/{}/{}".format(
+        storage_url, container_name, object_path))
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("--debug", action="store_true", default=False)
+    parser.add_argument("container_name")
+    parser.add_argument("swift_object_path")
+    parser.add_argument("local_path")
+    parser.add_argument("build_label")
+    args = parser.parse_args()
+
+    if args.debug:
+        # Print OpenStack-related environment variables for ease of
+        # debugging.  Only OS_AUTH_TOKEN and OS_PASSWORD currently seem to
+        # be secret, but for safety we only show unredacted contents of
+        # variables specifically known to be safe.  See "swift --os-help"
+        # for most of these.
+        safe_keys = {
+            "OS_AUTH_URL",
+            "OS_AUTH_VERSION",
+            "OS_CACERT",
+            "OS_CERT",
+            "OS_ENDPOINT_TYPE",
+            "OS_IDENTITY_API_VERSION",
+            "OS_INTERFACE",
+            "OS_KEY",
+            "OS_PROJECT_DOMAIN_ID",
+            "OS_PROJECT_DOMAIN_NAME",
+            "OS_PROJECT_ID",
+            "OS_PROJECT_NAME",
+            "OS_REGION_NAME",
+            "OS_SERVICE_TYPE",
+            "OS_STORAGE_URL",
+            "OS_TENANT_ID",
+            "OS_TENANT_NAME",
+            "OS_USERNAME",
+            "OS_USER_DOMAIN_ID",
+            "OS_USER_DOMAIN_NAME",
+            "OS_USER_ID",
+            }
+        for key, value in sorted(os.environ.items()):
+            if key.startswith("OS_"):
+                if key not in safe_keys:
+                    value = "<redacted>"
+                print("{}: {}".format(key, value))
+
+    overwrite = "FORCE_REBUILD" in os.environ
+    ensure_container_privs(args.container_name)
+    publish_file_to_swift(
+        args.container_name, args.swift_object_path, args.local_path,
+        overwrite=overwrite)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filename = "last-successful-build-label.txt"
+        with open(os.path.join(tmpdir, filename), "w") as f:
+            f.write(args.build_label)
+        publish_file_to_swift(
+            args.container_name, filename, os.path.join(tmpdir, filename),
+            overwrite=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/publish-to-swift
+++ b/publish-to-swift
@@ -1,6 +1,8 @@
 #! /usr/bin/python3
 
-"""Publish a built tarball to Swift for deployment."""
+"""Publish a built tarball to Swift for deployment.
+Script from: https://git.launchpad.net/turnip/tree/publish-to-swift
+"""
 
 from argparse import ArgumentParser
 import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+psycopg2==2.8.5
+lazr.postgresql==0.0.4


### PR DESCRIPTION
To be able to build and deploy serial-vault in the same way we deploy other stores services we need to have `ols-vms.conf` file in the root of the project.

Also added a Makefile target to build a tarball with binaries and static web files. So we can use only the Makefile during the build process and can get rid of some internal scripts.