### PR TITLE
Add command-line option to add an account

### DIFF
--- a/manage/account.go
+++ b/manage/account.go
@@ -22,4 +22,5 @@ package manage
 // AccountCommand is the main command for account management
 type AccountCommand struct {
 	Cache AccountCacheCommand `command:"cache" alias:"c" description:"Cache the account assertions from the store in the database"`
+	Add   AccountAddCommand   `command:"add" alias:"a" description:"Add a new account"`
 }

--- a/manage/account_test.go
+++ b/manage/account_test.go
@@ -46,7 +46,16 @@ func (s *AccountSuite) TestAccount(c *check.C) {
 			ErrorMessage: "Unknown command `invalid'. You should use the cache command"},
 		{
 			Args:         []string{"serial-vault-admin", "account", "cache"},
-			ErrorMessage: ""},
+			ErrorMessage: "",
+		},
+		{
+			Args:         []string{"serial-vault-admin", "account", "add", "acc123"},
+			ErrorMessage: "",
+		},
+		{
+			Args:         []string{"serial-vault-admin", "account", "add", "acc123", "-r"},
+			ErrorMessage: "",
+		},
 	}
 
 	for _, t := range tests {

--- a/manage/accountadd.go
+++ b/manage/accountadd.go
@@ -1,0 +1,43 @@
+package manage
+
+import (
+	"fmt"
+	"github.com/CanonicalLtd/serial-vault/datastore"
+)
+
+// AccountAddCommand handles adding a new account for the serial-vault-admin command
+type AccountAddCommand struct {
+	ResellerAPI bool `short:"r" long:"reseller" description:"Enable the reseller API"`
+}
+
+// Execute the adding of an account
+func (cmd AccountAddCommand) Execute(args []string) error {
+	err := checkAccountIDArg(args, "Add")
+	if err != nil {
+		return err
+	}
+
+	// Open the database and create the account
+	openDatabase()
+	account := datastore.Account{
+		AuthorityID: args[0],
+		ResellerAPI: cmd.ResellerAPI,
+	}
+	if err := datastore.Environ.DB.CreateAccount(account); err != nil {
+		return fmt.Errorf("error creating the account: %v", err)
+	}
+
+	fmt.Printf("Account '%s' created successfully\n", account.AuthorityID)
+	return nil
+}
+
+func checkAccountIDArg(args []string, action string) error {
+	switch len(args) {
+	case 0:
+		return fmt.Errorf("%s account expects an 'account ID' argument", action)
+	case 1:
+		return nil
+	default:
+		return fmt.Errorf("%s account expects a single 'account ID' argument", action)
+	}
+}


### PR DESCRIPTION
This is needed when the serial-vault is used on-premise with enableUserAuth turned off.
Closes #340 