### PR TITLE
Don't remove single quotes from headers

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -133,7 +133,7 @@ if [ "$STATIC" = 1 ]; then
 
     echo Checking for ineffective assignments
     # ineffassign knows about ignoring vendor/ \o/
-    ./bin/ineffassign .
+    ./bin/ineffassign ./...
 
     echo Checking for naked returns
     got=$(./bin/nakedret ./... 2>&1)

--- a/service/sign/handlers_sign.go
+++ b/service/sign/handlers_sign.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/CanonicalLtd/serial-vault/service/log"
@@ -255,17 +254,10 @@ func Serial(w http.ResponseWriter, r *http.Request) response.ErrorResponse {
 	return response.ErrorResponse{Success: true}
 }
 
-// CleanHeader removes single quotes and leading and trailing white spaces from the header
-func CleanHeader(header string) string {
-	header = strings.Replace(header, "'", "", -1)
-	header = strings.TrimSpace(header)
-	return header
-}
-
 func checkRemodelingRequest(serialReq *asserts.SerialRequest, modelAssert, serialAssert asserts.Assertion, apiKey string) response.ErrorResponse {
 	originalBrandID := serialReq.HeaderString("original-brand-id")
 	originalModel := serialReq.HeaderString("original-model")
-	originalSerial := CleanHeader(serialReq.HeaderString("original-serial"))
+	originalSerial := serialReq.HeaderString("original-serial")
 
 	if modelAssert == nil {
 		const msg = "Model assertion can't be empty for a remodeling request"

--- a/service/sign/handlers_sign_test.go
+++ b/service/sign/handlers_sign_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/CanonicalLtd/serial-vault/datastore"
 	"github.com/CanonicalLtd/serial-vault/service"
 	"github.com/CanonicalLtd/serial-vault/service/response"
-	"github.com/CanonicalLtd/serial-vault/service/sign"
 	"github.com/snapcore/snapd/asserts"
 	check "gopkg.in/check.v1"
 )
@@ -659,38 +658,5 @@ func (s *SignSuite) TestRemodeling(c *check.C) {
 		c.Assert(w.Header().Get("Content-Type"), check.Equals, t.Type)
 
 		datastore.Environ.DB = &datastore.MockDB{}
-	}
-}
-
-func (s *SignSuite) TestCleanHeader(c *check.C) {
-	tests := []struct {
-		name   string
-		header string
-		want   string
-	}{
-		{
-			name:   "case-1",
-			header: `'abc123'`,
-			want:   "abc123",
-		},
-		{
-			name:   "case-2",
-			header: `abc123 `,
-			want:   "abc123",
-		},
-		{
-			name:   "case-3",
-			header: "abc123",
-			want:   "abc123",
-		},
-		{
-			name:   "case-4",
-			header: "",
-			want:   "",
-		},
-	}
-	for _, tt := range tests {
-		got := sign.CleanHeader(tt.header)
-		c.Assert(got, check.Equals, tt.want)
 	}
 }


### PR DESCRIPTION
This is a revert for the change https://github.com/CanonicalLtd/serial-vault/pull/287
Wrong quoted serial-numbers in the header should be cleaned on the client-side