### PR TITLE
Add support to the charm for Bionic and Focal

### DIFF
--- a/.github/workflows/pr-golang.yaml
+++ b/.github/workflows/pr-golang.yaml
@@ -3,7 +3,7 @@ on: [pull_request]
 jobs:
   build:
     name: Test
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Set up Go
       uses: actions/setup-go@v1

--- a/charm/Makefile
+++ b/charm/Makefile
@@ -10,7 +10,6 @@ endif
 
 TMPDIR ?= $(CURDIR)/tmp_charm
 CHARM_SRC ?= $(CURDIR)/charm
-CHARM_SERIES ?= xenial
 CHARM_EXCLUDE_FILE ?= build-exclude.txt
 PROJECT_WHEEL_DIR ?= $(TMPDIR)/dependencies
 
@@ -25,7 +24,7 @@ PRIVATE_CHARM_REPO_DIR = $(BUILDDIR)/build-$(LP_USER)
 PRIVATE_PUBLISH_REPO = $(shell echo "$(CHARM_PUBLISH_REPO)" | sed -e 's/~[^/]*\//~$(LP_USER)\//')
 
 JUJU_REPOSITORY = $(BUILDDIR)
-CHARM_BUILD_DIR = $(BUILDDIR)/$(CHARM_SERIES)/$(CHARM_NAME)
+CHARM_BUILD_DIR = $(BUILDDIR)/$(CHARM_NAME)
 
 
 LAYER_PATH = $(TMPDIR)/ols-layers/layer
@@ -73,7 +72,7 @@ $(CHARM_DEPS): $(CHARM_SRC)/dependencies.txt $(CODETREE) | $(BASENODE_CACHE) $(T
 .PHONY: $(CHARM_BUILD_DIR)
 $(CHARM_BUILD_DIR): $(CHARM_DEPS) | $(BUILDDIR)
 	rm -rf $(CHARM_BUILD_DIR)
-	PIP_NO_INDEX=true PIP_FIND_LINKS=$(CHARM_WHEELS_DIR) charm build -o $(BUILDDIR) -s $(CHARM_SERIES) -n $(CHARM_NAME) ./charm/serial-vault
+	PIP_NO_INDEX=true PIP_FIND_LINKS=$(CHARM_WHEELS_DIR) charm build -o $(BUILDDIR) -n $(CHARM_NAME) ./charm/serial-vault
 
 /snap/bin/charm:
 	sudo snap install charm --classic

--- a/charm/bundle.yaml.in
+++ b/charm/bundle.yaml.in
@@ -1,9 +1,8 @@
-series: xenial
 description: Serial-Vault development bundle
 applications:
     serial-vault-admin:
         num_units: 1
-        charm: ../dist/xenial/serial-vault
+        charm: ../dist/serial-vault
         options:
             # ols layer config
             build_label: ${BUILD_LABEL}
@@ -21,7 +20,7 @@ applications:
             enableUserAuth: false
     serial-vault-signing:
         num_units: 1
-        charm: ../dist/xenial/serial-vault
+        charm: ../dist/serial-vault
         options:
             # ols layer config
             build_label: ${BUILD_LABEL}

--- a/charm/dependencies.txt
+++ b/charm/dependencies.txt
@@ -1,3 +1,2 @@
-ols-layers    git+ssh://git.launchpad.net/~ubuntuone-pqm-team/ols-charm-deps/+git/ols-layers;revno=123deb23
-charm-wheels  git+ssh://git.launchpad.net/~ubuntuone-hackers/ols-charm-deps/+git/wheels;revno=555749f1
-
+ols-layers      git+ssh://git.launchpad.net/~ubuntuone-pqm-team/ols-charm-deps/+git/ols-layers;revno=f148ad6d7684c963de86cae2b9ad701a13b509f4
+charm-wheels    git+ssh://git.launchpad.net/~ubuntuone-hackers/ols-charm-deps/+git/wheels;revno=HEAD

--- a/charm/serial-vault/metadata.yaml
+++ b/charm/serial-vault/metadata.yaml
@@ -6,6 +6,8 @@ maintainers:
 description: "A Go web service that digitally signs device assertion details."
 subordinate: false
 series:
+  - focal
+  - bionic
   - xenial
 provides:
   serial-vault:


### PR DESCRIPTION
Xenial, Bionic and Focal, can live next to eachother as the go snap is
used to ensure consistency of the used golang compiler version across
the charms,
Updated the charm dependencies to a version that supports all up to
focal