### PR TITLE
Bump Serial Vault CI builder to Jammy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ LDFLAGS += -X github.com/CanonicalLtd/serial-vault/config.revision=$(GIT_REVISIO
 # This will make the linked C part also static into the binary (can produce some warnings)
 LDFLAGS_STATIC += $(LDFLAGS) -linkmode external -extldflags -static
 
+# skip warning: "sqlite3-binding.c: In function ‘sqlite3SelectNew’" in go-sqlite3
+export CGO_CFLAGS += -Wno-return-local-addr
+
 GOFLAGS=-mod=vendor
 # make sure we use built-in net package and not the system’s one
 GOTAGS=-tags netgo

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ NEVER set this configuration in production environments.
 
 ## Install from Source
 If you have a Go development environment set up, we recommend at least Go v1.13 or higher. This project is built
-and tested on `Ubuntu 16.04.7 LTS (Xenial Xerus)` with `go 1.13`. If you wish to build or run the service from source we
+and tested on `Ubuntu 22.04 LTS (Jammy Jellyfish)` with `go 1.22.6` (`go` snap revision 10679). If you wish to build or run the service from source we
 recommend using LXD container for this purpose. To get started with LXD, please follow this 
 [wiki](https://wiki.canonical.com/UbuntuOne/Developer/LXC) (jump to the LXD section):
 
   ```bash
-  lxc launch ubuntu:16.04 serial-vault -p default -p $USER
+  lxc launch ubuntu:22.04 serial-vault -p default -p $USER
   lxc ls
   ssh -A <container-ip>
   serial-vault:~$ git clone https://github.com/canonical/serial-vault.git

--- a/ols-vms.conf
+++ b/ols-vms.conf
@@ -2,7 +2,7 @@
 
 vm.class = lxd
 vm.architecture = amd64
-vm.release = xenial
+vm.release = jammy
 vm.update = True
 vm.packages = @dependencies.txt, @dependencies-devel.txt, @charm/packages.txt
 jenkaas.secrets = swift/serial-vault:.config/swift/serial-vault


### PR DESCRIPTION
Serial vault is built with the go snap, and is thus fairly agnostic to the OS series.
This commit bumps xenial to jammy in ols-vms.conf so that the Jenkins build container will now be jammy.